### PR TITLE
added python 3 compatibility

### DIFF
--- a/mercadopago/__init__.py
+++ b/mercadopago/__init__.py
@@ -1,1 +1,1 @@
-from mercadopago import MP
+from .mercadopago import MP

--- a/mercadopago/mercadopago.py
+++ b/mercadopago/mercadopago.py
@@ -81,7 +81,7 @@ class MP(object):
     def get_payment(self, id):
         """
         Get information for specific payment
-        
+
         @param id
         @return json
         """
@@ -99,48 +99,39 @@ class MP(object):
     def get_authorized_payment(self, id):
         """
         Get information for specific authorized payment
-        
+
         @param id
         @return json
-        """    
-
-        try:
-            access_token = self.get_access_token()
-        except Exception,e:
-            raise e
-        
+        """
+        access_token = self.get_access_token()
         authorized_payment_info = self.__rest_client.get("/authorized_payments/"+id+"?access_token="+access_token)
         return authorized_payment_info
 
-    
+
     def refund_payment(self, id):
         """
         Refund accredited payment
-        
+
         @param id
         @return json
         """
-    
+
         access_token = self.get_access_token()
-
         refund_status = {"status":"refunded"}
-
         response = self.__rest_client.put("/collections/"+id+"?access_token="+access_token, refund_status)
         return response
 
-    
+
     def cancel_payment(self, id):
         """
         Cancel pending payment
-        
+
         @param id
         @return json
         """
-    
+
         access_token = self.get_access_token()
-
         cancel_status = {"status":"cancelled"}
-
         response = self.__rest_client.put("/collections/"+id+"?access_token="+access_token, cancel_status)
         return response
 
@@ -148,26 +139,21 @@ class MP(object):
     def cancel_preapproval_payment(self, id):
         """
         Cancel preapproval payment
-        
+
         @param id
         @return json
-        """    
+        """
 
-        try:
-            access_token = self.get_access_token()
-        except Exception,e:
-            raise e
-
+        access_token = self.get_access_token()
         cancel_status = {"status":"cancelled"}
-        
         response = self.__rest_client.put("/preapproval/"+id+"?access_token="+access_token, cancel_status)
         return response
-    
+
 
     def search_payment(self, filters, offset=0, limit=0):
         """
         Search payments according to filters, with pagination
-        
+
         @param filters
         @param offset
         @param limit
@@ -175,7 +161,6 @@ class MP(object):
         """
 
         access_token = self.get_access_token()
-
         filters["access_token"] = access_token
         filters["offset"] = offset
         filters["limit"] = limit
@@ -188,13 +173,12 @@ class MP(object):
     def create_preference(self, preference):
         """
         Create a checkout preference
-        
+
         @param preference
         @return json
         """
 
         access_token = self.get_access_token()
-
         preference_result = self.__rest_client.post("/checkout/preferences?access_token="+access_token, preference)
         return preference_result
 
@@ -202,14 +186,13 @@ class MP(object):
     def update_preference(self, id, preference):
         """
         Update a checkout preference
-        
+
         @param id
         @param preference
         @return json
         """
 
         access_token = self.get_access_token()
-
         preference_result = self.__rest_client.put("/checkout/preferences/"+id+"?access_token="+access_token, preference)
         return preference_result
 
@@ -217,32 +200,27 @@ class MP(object):
     def get_preference(self, id):
         """
         Update a checkout preference
-        
+
         @param id
         @param preference
         @return json
         """
         access_token = self.get_access_token()
-
         preference_result = self.__rest_client.get("/checkout/preferences/"+id+"?access_token="+access_token)
         return preference_result
-    
+
 
     def create_preapproval_payment(self, preapproval_payment):
         """
         Create a preapproval payment
-        
+
         @param preapproval_payment
         @return json
         """
-        try:
-            access_token = self.get_access_token()
-        except Exception,e:
-            raise e
-
+        access_token = self.get_access_token()
         preapproval_payment_result = self.__rest_client.post("/preapproval?access_token="+access_token, preapproval_payment)
         return preapproval_payment_result
-    
+
     def get_preapproval_payment(self, id):
         """
         Get a preapproval payment
@@ -251,14 +229,10 @@ class MP(object):
         @return json
 
         """
-        try:
-            access_token = self.get_access_token()
-        except Exception,e:
-            raise e
-        
+        access_token = self.get_access_token()
         preapproval_payment_result = self.__rest_client.get("/preapproval/"+id+"?access_token="+access_token)
         return preapproval_payment_result
-    
+
     def update_preapproval_payment(self, id, preapproval_payment):
         """
         Update a preapproval payment
@@ -267,14 +241,10 @@ class MP(object):
         @return json
 
         """
-        try:
-            access_token = self.get_access_token()
-        except Exception,e:
-            raise e
-        
+        access_token = self.get_access_token()
         preapproval_payment_result = self.__rest_client.put("/preapproval/"+id+"?access_token="+access_token, preapproval_payment)
         return preapproval_payment_result
-    
+
     def get(self, uri, params=None, authenticate=True):
         """
         Generic resource get
@@ -287,15 +257,12 @@ class MP(object):
             params = {}
 
         if authenticate:
-            try:
-                access_token = self.get_access_token()
-                params["access_token"] = access_token
-            except Exception,e:
-                raise e
+            access_token = self.get_access_token()
+            params["access_token"] = access_token
 
         result = self.__rest_client.get(uri, params)
         return result
-    
+
     def post(self, uri, data, params=None):
         """
         Generic resource post
@@ -307,15 +274,11 @@ class MP(object):
         if params is None:
             params = {}
 
-        try:
-            access_token = self.get_access_token()
-            params["access_token"] = access_token
-        except Exception,e:
-            raise e
-
+        access_token = self.get_access_token()
+        params["access_token"] = access_token
         result = self.__rest_client.post(uri, data, params)
         return result
-    
+
     def put(self, uri, data, params=None):
         """
         Generic resource put
@@ -327,15 +290,11 @@ class MP(object):
         if params is None:
             params = {}
 
-        try:
-            access_token = self.get_access_token()
-            params["access_token"] = access_token
-        except Exception,e:
-            raise e
-
+        access_token = self.get_access_token()
+        params["access_token"] = access_token
         result = self.__rest_client.put(uri, data, params)
         return result
-    
+
     def delete(self, uri, params=None):
         """
         Generic resource delete
@@ -346,15 +305,11 @@ class MP(object):
         if params is None:
             params = {}
 
-        try:
-            access_token = self.get_access_token()
-            params["access_token"] = access_token
-        except Exception,e:
-            raise e
-
+        access_token = self.get_access_token()
+        params["access_token"] = access_token
         result = self.__rest_client.delete(uri, params)
         return result
-    
+
     ##################################################################################
     class __RestClient(object):
         __API_BASE_URL = "https://api.mercadopago.com"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='horacio.casatti@mercadolibre.com',
     keywords='api mercadopago checkout payment ipn sdk integration',
     packages=['mercadopago'],
-    url='https://github.com/mercadopago/sdk-python.git',
+    url='https://github.com/mercadopago/sdk-python',
     description='Mercadopago SDK module for Payments integration',
     long_description=open('README.rst').read(),
     install_requires='requests>=2.4.3',
@@ -41,6 +41,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: Freely Distributable',
     ]

--- a/tests/test_https_certificate_check.py
+++ b/tests/test_https_certificate_check.py
@@ -1,4 +1,9 @@
-import BaseHTTPServer, SimpleHTTPServer
+try:
+    from BaseHTTPServer import HTTPServer
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+except ImportError:
+    from http.server import HTTPServer, SimpleHTTPRequestHandler
+
 import ssl
 import unittest
 
@@ -34,13 +39,13 @@ class TestHttps(unittest.TestCase):
     def setUp(self):
         self.unset_proxy_environment_variables()
 
-        self.handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+        self.handler = SimpleHTTPRequestHandler
 
         self.httpd_port = None
         self.httpd = None
         for port_to_try in range(8000, 8099):
             try:
-                self.httpd = BaseHTTPServer.HTTPServer(('localhost', port_to_try),
+                self.httpd = HTTPServer(('localhost', port_to_try),
                                                        self.handler)
                 self.httpd_port = port_to_try
                 break


### PR DESCRIPTION
This patch add compatibility to work with Python 3, which is the preferred language for new project for many programmer (specially for a web scope). Fix #17 

In fact, most of the syntax errors were in line `except Exception,e:` which is deprecated in python 2 and should be `except Exception as e:` that works both un python 2 and 3. 

But going deeper, catch *any* exception (as `except Exception` does) to just raise it again it's a nonsense, so I removed them. Now, the behaviour is the same:  if `self.get_access_token()` raises an exception and we want to know that, there is no need to catch it. 
