### PR TITLE
Reference README.md instead of README.rst

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst
+include README.md
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=["mercadopago"],
     url="https://github.com/mercadopago/sdk-python",
     description="Mercadopago SDK module for Payments integration",
-    long_description=open("README.rst").read(),
+    long_description=open("README.md").read(),
     install_requires="requests>=2.4.3",
     cmdclass={"test": Tests},
     classifiers=[


### PR DESCRIPTION
This build currently breaks because the code references README.rst, it should be changed to README.md.