### PR TITLE
hotfix: dont getAuthHeader when authenticating

### DIFF
--- a/mercadopago/mercadopago.py
+++ b/mercadopago/mercadopago.py
@@ -340,7 +340,10 @@ class MP(object):
                 data = JSONEncoder().encode(data)
 
             s = self.get_session()
-            api_result = s.post(self.__API_BASE_URL+uri, params=params, data=data, headers={'x-product-id': self.PRODUCT_ID, 'x-tracking-id': self.TRACKING_ID, 'User-Agent':self.USER_AGENT, 'Content-type':content_type, 'Accept':self.MIME_JSON, 'x-platform-id':self.__outer.platform_id, 'x-integrator-id':self.__outer.integrator_id, 'x-corporation-id':self.__outer.corporation_id, self.AUTH_HEADER: self.getAuthorizationHeader()})
+            headers = {'x-product-id': self.PRODUCT_ID, 'x-tracking-id': self.TRACKING_ID, 'User-Agent':self.USER_AGENT, 'Content-type':content_type, 'Accept':self.MIME_JSON, 'x-platform-id':self.__outer.platform_id, 'x-integrator-id':self.__outer.integrator_id, 'x-corporation-id':self.__outer.corporation_id}
+            if uri.find('/oauth/token') == -1:
+                headers[self.AUTH_HEADER] = self.getAuthorizationHeader()
+            api_result = s.post(self.__API_BASE_URL+uri, params=params, data=data, headers=headers)
 
             response = {
                 "status": api_result.status_code,


### PR DESCRIPTION
When calling any API it tries to get the AuthHeaders, if token is not present it tries to authenticate but as it uses the same method as before for calling the API it ends up in a loop.

```
api_result = s.post(self.__API_BASE_URL+uri, params=params, data=data, headers={'x-product-id': self.PRODUCT_ID, 'x-tracking-id': self.TRACKING_ID, 'User-Agent':self.USER_AGENT, 'Content-type':content_type, 'Accept':self.MIME_JSON, 'x-platform-id':self.__outer.platform_id, 'x-integrator-id':self.__outer.integrator_id, 'x-corporation-id':self.__outer.corporation_id, self.AUTH_HEADER: self.getAuthorizationHeader()})
  File "/usr/local/lib/python3.7/site-packages/mercadopago/mercadopago.py", line 325, in getAuthorizationHeader
    return 'Bearer ' + self.__outer.get_access_token()
  File "/usr/local/lib/python3.7/site-packages/mercadopago/mercadopago.py", line 78, in get_access_token
    access_data = self.__rest_client.post("/oauth/token", None, app_client_values, self.__RestClient.MIME_FORM)
  File "/usr/local/lib/python3.7/site-packages/mercadopago/mercadopago.py", line 342, in post
    s = self.get_session()
  File "/usr/local/lib/python3.7/site-packages/mercadopago/mercadopago.py", line 319, in get_session
    session = requests.Session()
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 367, in __init__
    self.headers = default_headers()
  File "/usr/local/lib/python3.7/site-packages/requests/utils.py", line 815, in default_headers
    'Connection': 'keep-alive',
  File "/usr/local/lib/python3.7/site-packages/requests/structures.py", line 46, in __init__
    self.update(data, **kwargs)
  File "/usr/local/lib/python3.7/_collections_abc.py", line 839, in update
    if isinstance(other, Mapping):
  File "/usr/local/lib/python3.7/abc.py", line 139, in __instancecheck__
    return _abc_instancecheck(cls, instance)
RecursionError: maximum recursion depth exceeded in comparison
```