### PR TITLE
Fix SDK installation error

### DIFF
--- a/mercadopago/config/config.py
+++ b/mercadopago/config/config.py
@@ -10,7 +10,7 @@ class Config():
     """
 
     def __init__(self):
-        self.__version = "2.0.6"
+        self.__version = "2.0.7"
         self.__user_agent = "MercadoPago Python SDK v" + self.__version
         self.__product_id = "bc32bpftrpp001u8nhlg"
         self.__tracking_id = "platform:" + platform.python_version()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     tests_require=[
         "unittest"
     ],
-    python_requires="!=3.0*",
+    python_requires=">=3",
     cmdclass={"test": unittest},
     project_urls={
         "Source Code": "https://github.com/mercadopago/sdk-python",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mercadopago",
-    version="2.0.6",
+    version="2.0.7",
     description="Mercadopago SDK module for Payments integration",
     author="Mercado Pago SDK",
     author_email="mp_sdk@mercadopago.com",
@@ -19,6 +19,9 @@ setup(
     include_package_data=True,
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
+    install_requires=[
+        "requests"
+    ],
     tests_require=[
         "unittest"
     ],

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -41,7 +41,7 @@ class TestCard(unittest.TestCase):
         }
 
         card_created = self.sdk.card().create(customer_id, card_object)
-        self.assertEqual(card_created["status"], 200)
+        self.assertIn(card_created["status"], [200, 201])
         self.assertEqual(self.sdk.card()
         .get(customer_id, card_created["response"]["id"])["status"], 200)
 


### PR DESCRIPTION
* Add `requests` as a required dependency
* Increment SDK version to 2.0.7

Closes #46 