### PR TITLE
Deduplicate some client functions

### DIFF
--- a/mercadopago/http/http_client.py
+++ b/mercadopago/http/http_client.py
@@ -11,9 +11,6 @@ class HttpClient():
     Default implementation to call all REST API's
     """
 
-    def __init__(self):
-        pass
-
     @staticmethod
     def __get_session(max_retries):
         retry_strategy = Retry(
@@ -24,9 +21,9 @@ class HttpClient():
         http.mount("https://", HTTPAdapter(max_retries=retry_strategy))
         return http
 
-    def get(self, url, headers, params=None, timeout=None, maxretries=None): #pylint: disable=missing-function-docstring, too-many-arguments
+    def request(self, method, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
         with self.__get_session(maxretries) as session:
-            api_result = session.get(url, params=params, headers=headers, timeout=timeout)
+            api_result = session.request(method, url, params=params, headers=headers, timeout=timeout)
             response = {
                 "status": api_result.status_code,
                 "response": api_result.json()
@@ -34,34 +31,14 @@ class HttpClient():
 
         return response
 
-    def post(self, url, headers, data=None, params=None, timeout=None, maxretries=None): #pylint: disable=missing-function-docstring, too-many-arguments
-        with self.__get_session(maxretries) as session:
-            api_result = session.post(url, params=params, data=data,
-            headers=headers, timeout=timeout)
-            response = {
-                "status": api_result.status_code,
-                "response": api_result.json()
-            }
+    def get(self, url, headers, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
+        return self.request("GET", url=url, headers=headers, params=params, timeout=timeout, maxretries=maxretries)
 
-        return response
+    def post(self, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
+        return self.request("POST", url=url, headers=headers, data=data, params=params, timeout=timeout, maxretries=maxretries)
 
-    def put(self, url, headers, data=None, params=None, timeout=None, maxretries=None): #pylint: disable=missing-function-docstring, too-many-arguments
-        with self.__get_session(maxretries) as session:
-            api_result = session.put(url, params=params, data=data,
-            headers=headers, timeout=timeout)
-            response = {
-                "status": api_result.status_code,
-                "response": api_result.json()
-            }
+    def put(self, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
+        return self.request("PUT", url=url, headers=headers, data=data, params=params, timeout=timeout, maxretries=maxretries)
 
-        return response
-
-    def delete(self, url, headers, params=None, timeout=None, maxretries=None): #pylint: disable=missing-function-docstring, too-many-arguments
-        with self.__get_session(maxretries) as session:
-            api_result = session.delete(url, params=params, headers=headers, timeout=timeout)
-            response = {
-                "status": api_result.status_code,
-                "response": api_result.json()
-            }
-
-        return response
+    def delete(self, url, headers, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
+        return self.request("DELETE", url=url, headers=headers, params=params, timeout=timeout, maxretries=maxretries)

--- a/mercadopago/http/http_client.py
+++ b/mercadopago/http/http_client.py
@@ -11,19 +11,19 @@ class HttpClient():
     Default implementation to call all REST API's
     """
 
-    @staticmethod
-    def __get_session(max_retries):
+    def request(self, method, url, maxretries=None, **kwargs):
+        """Makes a call to the API.
+
+        All **kwargs are passed verbatimm to ``requests.request``.
+        """
         retry_strategy = Retry(
-            total=max_retries,
+            total=maxretries,
             status_forcelist=[429, 500, 502, 503, 504]
         )
         http = requests.Session()
         http.mount("https://", HTTPAdapter(max_retries=retry_strategy))
-        return http
-
-    def request(self, method, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=missing-function-docstring, too-many-arguments
-        with self.__get_session(maxretries) as session:
-            api_result = session.request(method, url, params=params, headers=headers, timeout=timeout)
+        with http as session:
+            api_result = session.request(method, url, **kwargs)
             response = {
                 "status": api_result.status_code,
                 "response": api_result.json()


### PR DESCRIPTION
A few of these functions were pretty much a copy-paste of each other, so
I've de-duplicated these and just re-use the same block for all of them.

This improves readability a bit, and makes it a bit more obvious that all
of these actually do the same (I really came across this trying to understand
a bit better how some internals of the SDK work).

I've also deleted an initialiser that did nothing, since that mostly adds
noise/complexity.