### PR TITLE
Add preferences search method

### DIFF
--- a/mercadopago/resources/preference.py
+++ b/mercadopago/resources/preference.py
@@ -68,3 +68,19 @@ class Preference(MPBase):
 
         return self._post(uri="/checkout/preferences", data=preference_object,
                           request_options=request_options)
+
+    def search(self, filters=None, request_options=None):
+        """[Click here for more info](https://www.mercadopago.com.br/developers/en/reference/preferences/_checkout_preferences_search/get)  # pylint: disable=line-too-long
+
+        Args:
+            filters (dict): The search filters parameters
+            request_options (mercadopago.config.request_options, optional): An instance of
+            RequestOptions can be pass changing or adding custom options to ur REST call.
+            Defaults to None.
+
+        Returns:
+            dict: Preference find response
+        """
+
+        return self._get(uri="/checkout/preferences/search", filters=filters,
+                         request_options=request_options)

--- a/tests/test_preference.py
+++ b/tests/test_preference.py
@@ -45,6 +45,11 @@ class TestPreference(unittest.TestCase):
         self.assertEqual(preference_saved["response"]["items"][0]["title"],
                          preference_object["items"][0]["title"])
 
+        preference_saved = self.sdk.preference().search()
+
+        self.assertEqual(preference_saved["response"]["elements"][0]["items"][0],
+                         preference_object["items"][0]["title"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adding preferences search method.

_Obs.: I followed the "filters" dict for params passing, although it would be more clear to use real params names and descriptions._