### PR TITLE
get user by id or me by default

### DIFF
--- a/mercadopago/resources/user.py
+++ b/mercadopago/resources/user.py
@@ -9,7 +9,7 @@ class User(MPBase):
     Access to Users
     """
 
-    def get(self, request_options=None):
+    def get(self, user_id="me", request_options=None):
         """Args:
             request_options (mercadopago.config.request_options, optional): An instance of
             RequestOptions can be pass changing or adding custom options to ur REST call.
@@ -18,7 +18,7 @@ class User(MPBase):
         Returns:
             dict: User find response
         """
-        return self._get(uri="/users/me", request_options=request_options)
+        return self._get(uri=f"/users/{user_id}", request_options=request_options)
 
     @property
     def request_options(self):


### PR DESCRIPTION
Improved the functionality by enabling the retrieval of user information through an user id, rather than relying on a hardcoded URI that only fetches details about our own account.