### PR TITLE
Fix URI formation in update method by adding missing '/'

### DIFF
--- a/mercadopago/resources/preapproval.py
+++ b/mercadopago/resources/preapproval.py
@@ -79,5 +79,5 @@ class PreApproval(MPBase):
         if not isinstance(preapproval_object, dict):
             raise ValueError("Param preapproval_object must be a Dictionary")
 
-        return self._put(uri="/preapproval" + str(preapproval_id),
+        return self._put(uri="/preapproval/" + str(preapproval_id),
                          data=preapproval_object, request_options=request_options)


### PR DESCRIPTION
In the update() method of the PreApproval class, a "/" was missing, otherwise the following error would occur:

{
   "status":404,
   "response":{
      "timestamp":"2024-06-23T22:17:09Z",
      "status":404,
      "error":"Not Found",
      "path":"/preapproval{id}"
   }
}