### PR TITLE
Async Support

### DIFF
--- a/mercadopago/__init__.py
+++ b/mercadopago/__init__.py
@@ -2,8 +2,9 @@
 Module: mercadopago/__init__.py
 """
 from mercadopago.sdk import SDK
-
+from mercadopago.async_sdk import AsyncSDK
 
 __all__ = (
     'SDK',
+    'AsyncSDK'
 )

--- a/mercadopago/async_sdk.py
+++ b/mercadopago/async_sdk.py
@@ -1,0 +1,221 @@
+"""
+Module: async_sdk
+"""
+from mercadopago.config import RequestOptions
+from mercadopago.http import AsyncHttpClient
+from mercadopago.resources import (
+    AdvancedPayment,
+    Card,
+    CardToken,
+    Chargeback,
+    Customer,
+    DisbursementRefund,
+    IdentificationType,
+    MerchantOrder,
+    Order,
+    Payment,
+    PaymentMethods,
+    Plan,
+    PreApproval,
+    Preference,
+    Refund,
+    Subscription,
+    User,
+)
+
+
+class AsyncSDK:
+    """Generate access to all API' modules, which are:
+
+        1. Advanced Payment
+        2. Card Token
+        3. Card
+        4. Customer
+        5. Disbursement Refund
+        6. Identification Type
+        7. Merchant Order
+        8. Order
+        9. Payment Methods
+        10. Payment
+        11. Preapproval
+        12. Preference
+        13. Refund
+        14. User
+        15. Chargeback
+        16. Subscription
+        17. Plan
+    """
+
+    def __init__(
+        self,
+        access_token,
+        http_client: AsyncHttpClient = None,
+        request_options: RequestOptions = None,
+    ):
+        """Construct ur SDK Object to have access to all APIs modules on async context.
+        Args:
+            [Click here for more info](https://www.mercadopago.com/mlb/account/credentials)
+            http_client (mercadopago.http.http_client, optional): An implementation of
+            AsyncHttpClient can be pass to be used to make the REST calls. Defaults to None.
+            request_options (mercadopago.config.request_options, optional): An instance
+            of RequestOptions can be pass changing or adding custom options to ur REST
+            calls. Defaults to None.
+        Raises:
+            ValueError: Param request_options must be a RequestOptions Object
+        """
+
+        self.http_client = http_client
+        if http_client is None:
+            self.http_client = AsyncHttpClient()
+
+        self.request_options = request_options
+        if request_options is None:
+            self.request_options = RequestOptions()
+
+        self.request_options.access_token = access_token
+
+    def advanced_payment(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return AdvancedPayment(request_options is not None and request_options
+                               or self.request_options, self.http_client)
+
+    def card_token(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return CardToken(request_options is not None and request_options
+                         or self.request_options, self.http_client)
+
+    def card(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Card(request_options is not None and request_options
+                    or self.request_options, self.http_client)
+
+    def customer(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Customer(request_options is not None and request_options
+                        or self.request_options, self.http_client)
+
+    def disbursement_refund(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return DisbursementRefund(request_options is not None and request_options
+                                  or self.request_options, self.http_client)
+
+    def identification_type(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return IdentificationType(request_options is not None and request_options
+                                  or self.request_options, self.http_client)
+
+    def merchant_order(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return MerchantOrder(request_options is not None and request_options
+                             or self.request_options, self.http_client)
+
+    def order(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Order(request_options is not None and request_options
+                       or self.request_options, self.http_client)
+
+    def payment(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Payment(request_options is not None and request_options
+                       or self.request_options, self.http_client)
+
+    def payment_methods(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return PaymentMethods(request_options is not None and request_options
+                              or self.request_options, self.http_client)
+
+    def preapproval(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return PreApproval(request_options is not None and request_options
+                           or self.request_options, self.http_client)
+
+    def preference(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Preference(request_options is not None and request_options
+                          or self.request_options, self.http_client)
+
+    def refund(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Refund(request_options is not None and request_options
+                      or self.request_options, self.http_client)
+
+    def user(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return User(request_options is not None and request_options
+                    or self.request_options, self.http_client)
+
+    def chargeback(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Chargeback(request_options is not None and request_options
+                          or self.request_options, self.http_client)
+
+    def subscription(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Subscription(request_options is not None and request_options
+                            or self.request_options, self.http_client)
+
+    def plan(self, request_options=None):
+        """
+        Returns the attribute value of the function
+        """
+        return Plan(request_options is not None and request_options
+                    or self.request_options, self.http_client)
+
+    @property
+    def request_options(self):
+        """
+        Sets the attribute value and validates request_options
+        """
+        return self.__request_options
+
+    @request_options.setter
+    def request_options(self, value):
+        if value is not None and not isinstance(value, RequestOptions):
+            raise ValueError(
+                "Param request_options must be a RequestOptions Object")
+        self.__request_options = value
+
+    @property
+    def http_client(self):
+        """
+        Sets the attribute value and validates http_client
+        """
+        return self.__http_client
+
+    @http_client.setter
+    def http_client(self, value):
+        if value is not None and not isinstance(value, AsyncHttpClient):
+            raise ValueError("Param http_client must be a AsyncHttpClient Object")
+        self.__http_client = value

--- a/mercadopago/core/mp_base.py
+++ b/mercadopago/core/mp_base.py
@@ -1,11 +1,13 @@
 """
 Module: mp_base
 """
+from typing import Union, Coroutine, Any
+
 from json.encoder import JSONEncoder
 
 from mercadopago.config.config import Config
 from mercadopago.config.request_options import RequestOptions
-
+from mercadopago.http import HttpClient, AsyncHttpClient
 
 class MPBase:
     """All mercadopago.resources extends this one to call the REST services
@@ -15,14 +17,15 @@ class MPBase:
         An instance of RequestOptions can be pass changing or adding custom options
         to ur REST calls. Defaults to None.
         http_client (mercadopago.http.http_client, optional): An implementation of
-        HttpClient can be pass to be used to make the REST calls. Defaults to None.
+        HttpClient or AsyncHttpClient can be pass to be used to make the REST calls.
+        Defaults to None.
 
     Raises:
         ValueError: Param request_options must be a RequestOptions Object
         ValueError: Filters must be a Dictionary
     """
 
-    def __init__(self, request_options, http_client):
+    def __init__(self, request_options, http_client: Union[HttpClient, AsyncHttpClient]):
         if not isinstance(request_options, RequestOptions):
             raise ValueError(
                 "Param request_options must be a RequestOptions Object")
@@ -53,7 +56,7 @@ class MPBase:
 
         return headers
 
-    def _get(self, uri, filters=None, request_options=None):
+    def _get(self, uri, filters=None, request_options=None) -> Union[dict[str, int | None], Coroutine[Any, Any, dict[str, int | None]]]:
         if filters is not None and not isinstance(filters, dict):
             raise ValueError("Filters must be a Dictionary")
 
@@ -69,7 +72,7 @@ class MPBase:
             maxretries=request_options.max_retries,
         )
 
-    def _post(self, uri, data=None, params=None, request_options=None):
+    def _post(self, uri, data=None, params=None, request_options=None) -> Union[dict[str, int | None], Coroutine[Any, Any, dict[str, int | None]]]:
         if data is not None:
             data = JSONEncoder().encode(data)
 
@@ -86,7 +89,7 @@ class MPBase:
             maxretries=request_options.max_retries,
         )
 
-    def _put(self, uri, data=None, params=None, request_options=None):
+    def _put(self, uri, data=None, params=None, request_options=None) -> Union[dict[str, int | None], Coroutine[Any, Any, dict[str, int | None]]]:
         if data is not None:
             data = JSONEncoder().encode(data)
 
@@ -103,7 +106,7 @@ class MPBase:
             maxretries=request_options.max_retries,
         )
 
-    def _delete(self, uri, params=None, request_options=None):
+    def _delete(self, uri, params=None, request_options=None) -> Union[dict[str, int | None], Coroutine[Any, Any, dict[str, int | None]]]:
         request_options = self.__check_request_options(request_options)
         headers = self.__check_headers(request_options)
 

--- a/mercadopago/http/__init__.py
+++ b/mercadopago/http/__init__.py
@@ -1,9 +1,10 @@
 """
 Module: http/__init__.py
 """
-from mercadopago.http.http_client import HttpClient
+from mercadopago.http.http_client import HttpClient, AsyncHttpClient
 
 
 __all__ = (
     'HttpClient',
+    'AsyncHttpClient',
 )

--- a/mercadopago/http/http_client.py
+++ b/mercadopago/http/http_client.py
@@ -3,6 +3,8 @@ Module: http_client
 """
 # pylint: disable=too-many-arguments
 import requests
+import httpx
+from httpx_retries import Retry as AsyncRetry, RetryTransport
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
@@ -78,6 +80,83 @@ class HttpClient:
     # pylint: disable=too-many-positional-arguments
         """Makes a DELETE request to the API"""
         return self.request(
+            "DELETE",
+            url=url,
+            headers=headers,
+            params=params,
+            timeout=timeout,
+            maxretries=maxretries,
+        )
+
+class AsyncHttpClient:
+    """
+    Async implementation to call all REST API's
+    """
+
+    async def request(self, method: str, url, maxretries=None, **kwargs):
+        """Makes a call to the API.
+
+        All **kwargs are passed verbatim to ``httpx.request``.
+        """
+        retry_strategy = AsyncRetry(
+            total=maxretries,
+            status_forcelist=[429, 500, 502, 503, 504]
+        )
+        async with httpx.AsyncClient(transport=RetryTransport(retry=retry_strategy)) as session:
+            api_result = await session.request(method, url, **kwargs)
+            response = {"status": api_result.status_code, "response": None}
+
+            if api_result.status_code != 204 and api_result.content:
+                try:
+                    response["response"] = api_result.json()
+                except ValueError as e:
+                    print(f"Failed to parse JSON: {str(e)}")
+                    response["response"] = None
+
+            return response
+
+    async def get(self, url, headers, params=None, timeout=None, maxretries=None):  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+        """Makes a GET request to the API"""
+        return await self.request(
+            "GET",
+            url=url,
+            headers=headers,
+            params=params,
+            timeout=timeout,
+            maxretries=maxretries,
+        )
+
+    async def post(self, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+        """Makes a POST request to the API"""
+        return await self.request(
+            "POST",
+            url=url,
+            headers=headers,
+            data=data,
+            params=params,
+            timeout=timeout,
+            maxretries=maxretries,
+        )
+
+    async def put(self, url, headers, data=None, params=None, timeout=None, maxretries=None):  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+        """Makes a PUT request to the API"""
+        return await self.request(
+            "PUT",
+            url=url,
+            headers=headers,
+            data=data,
+            params=params,
+            timeout=timeout,
+            maxretries=maxretries,
+        )
+
+    async def delete(self, url, headers, params=None, timeout=None, maxretries=None):  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+        """Makes a DELETE request to the API"""
+        return await self.request(
             "DELETE",
             url=url,
             headers=headers,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ keywords = ["api", "mercadopago", "checkout", "payment in sdk integration", "lts
 license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
-    "requests"
+    "requests",
+    "httpx",
+    "httpx-retries"
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
In modern times, there are Python servers fully capable of running ASGi; it's good that the SDK also supports this.

I adapted it to implement AsyncSDK as an alternative SDK that uses an asynchronous HTTP client. I didn't change the API implementations or functionalities.

I didn't run the tests because it rejected the test credentials. If you can confirm that it's safe to use production credentials, I can try again.