### PR TITLE
Enhancement: update python version to 3.10 or higher

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
 **Environment (please complete the following information):**
 
 - OS: [e.g. Linux/Mac/Windows]
-- Python version: [e.g. 3.7]
+- Python version: [e.g. 3.10]
 - SDK version: [e.g. 2.0.0]
 
 **Additional context**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides developers with a simple set of bindings to help you integ
 
 ## 💡 Requirements
 
-Python 3 or higher.
+Python 3.10 or higher.
 
 ## 📲 Installation 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Mercadopago SDK module for Payments integration"
 readme = "README.md"
 keywords = ["api", "mercadopago", "checkout", "payment in sdk integration", "lts"]
 license = {file = "LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "requests"
 ]
@@ -21,14 +21,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pylint.MASTER]
-py-version = 3.7
+py-version = 3.10
 
 [pylint.FORMAT]
 max-line-length = 100


### PR DESCRIPTION
Python 3.9 is already at end-of life: https://devguide.python.org/versions/
Changed the CI to current versions of python, removing 3.9 and adding 3.13 and 3.14
Remove classifiers from python 3.4 to python 3.9 and added classifiers from python 3.12 to 3.14
