### PR TITLE
fix: remove unittest optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 
-[project.optional-dependencies]
-testing = [
-   "unittest"
-]
-
 [project.urls]
 Homepage = "https://mercadopago.com"
 Repository = "https://github.com/mercadopago/sdk-python"


### PR DESCRIPTION
unittest is part of the python standar library and it's not a dependency
If you try to install the dependency as:
`pip install .[testing]`
you get:
`No matching distribution found for unittest`