### PR TITLE
Remove Web Tokenize Checkout link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Visit our Dev Site for further information regarding:
  - [APIs](https://www.mercadopago.com/developers/en/reference)
  - [Checkout Pro](https://www.mercadopago.com/developers/en/guides/online-payments/checkout-pro/introduction)
  - [Checkout API](https://www.mercadopago.com/developers/en/guides/online-payments/checkout-api/introduction)
- - [Web Tokenize Checkout](https://www.mercadopago.com/developers/en/guides/online-payments/web-tokenize-checkout/introduction)
 
 Check our official code reference to explore all available functionalities.
 


### PR DESCRIPTION
Removed link to Web Tokenize Checkout from README. The Web Tokenize Checkout documentation link was pointing to a removed page. This change removes the reference to avoid confusion.