### PR TITLE
Add WebhookSignatureValidator utility

### DIFF
--- a/mercadopago/webhook/__init__.py
+++ b/mercadopago/webhook/__init__.py
@@ -1,0 +1,15 @@
+"""
+Module: webhook/__init__.py
+"""
+from mercadopago.webhook.validator import (
+    InvalidWebhookSignatureError,
+    SignatureFailureReason,
+    WebhookSignatureValidator,
+)
+
+
+__all__ = (
+    "InvalidWebhookSignatureError",
+    "SignatureFailureReason",
+    "WebhookSignatureValidator",
+)

--- a/mercadopago/webhook/validator.py
+++ b/mercadopago/webhook/validator.py
@@ -1,0 +1,221 @@
+"""MercadoPago webhook signature validator.
+
+Verifies the authenticity of incoming webhook notifications by recomputing
+the HMAC-SHA256 signature locally and comparing it against the value carried
+in the ``x-signature`` header.
+
+The validator is stateless, performs no outbound HTTP calls, and does not
+depend on any SDK configuration object; the integrator passes the secret
+signature explicitly on every call.
+"""
+import hmac
+import hashlib
+import re
+import time
+from enum import Enum
+
+
+class SignatureFailureReason(Enum):
+    """Reasons why :class:`WebhookSignatureValidator` may reject a notification.
+
+    Integrators are encouraged to log this value alongside the
+    ``x-request-id`` for correlation against the MercadoPago notifications
+    dashboard.
+    """
+
+    MISSING_SIGNATURE_HEADER = "MissingSignatureHeader"
+    """The ``x-signature`` header was missing, empty, or whitespace."""
+
+    MALFORMED_SIGNATURE_HEADER = "MalformedSignatureHeader"
+    """The header did not match the expected ``ts=...,vN=...`` format."""
+
+    MISSING_TIMESTAMP = "MissingTimestamp"
+    """The header parsed correctly but no ``ts=`` component was present."""
+
+    MISSING_HASH = "MissingHash"
+    """No hash was found for any of the requested ``supported_versions``."""
+
+    SIGNATURE_MISMATCH = "SignatureMismatch"
+    """The computed HMAC did not match the value in the header."""
+
+    TIMESTAMP_OUT_OF_TOLERANCE = "TimestampOutOfTolerance"
+    """The header timestamp fell outside the configured ``tolerance`` window."""
+
+
+class InvalidWebhookSignatureError(Exception):
+    """Raised by :func:`WebhookSignatureValidator.validate` on signature failure.
+
+    Carries enough context to support structured logging without exposing
+    internal details in the HTTP response body.
+
+    Attributes:
+        reason: Specific :class:`SignatureFailureReason` that triggered the error.
+        request_id: ``x-request-id`` header value, when available.
+        timestamp: ``ts`` value extracted from the signature header, when parsing
+            reached that point.
+    """
+
+    def __init__(self, reason, request_id=None, timestamp=None):
+        """Initialises the error.
+
+        Args:
+            reason: Specific failure mode.
+            request_id: ``x-request-id`` value associated with the request.
+            timestamp: ``ts`` extracted from the header, if available.
+        """
+        super().__init__("Invalid webhook signature: {0}".format(reason.value))
+        self.reason = reason
+        self.request_id = request_id
+        self.timestamp = timestamp
+
+
+_DEFAULT_SUPPORTED_VERSIONS = ("v1",)
+_VERSION_KEY_REGEX = re.compile(r"^v\d+$")
+
+
+class WebhookSignatureValidator:
+    """Stateless utility that validates the signature of a MercadoPago webhook.
+
+    On failure :func:`validate` raises :class:`InvalidWebhookSignatureError`;
+    on success it returns ``None``. The comparison is performed in constant
+    time via :func:`hmac.compare_digest` to mitigate timing attacks.
+
+    QR Code notifications are **not signed** by MercadoPago — do not call this
+    validator for those events; they will always fail signature verification.
+    """
+
+    @staticmethod
+    def validate(
+        x_signature,
+        x_request_id,
+        data_id,
+        secret,
+        tolerance_seconds=None,
+        supported_versions=None,
+        now=None,
+    ):
+        """Validates the signature of a MercadoPago webhook notification.
+
+        Args:
+            x_signature: Raw value of the ``x-signature`` request header.
+                Expected format: ``ts=<ms>,v1=<hex>``.
+            x_request_id: Value of the ``x-request-id`` request header. May be
+                ``None``; in that case the ``request-id:`` pair is omitted from
+                the manifest before computing the HMAC.
+            data_id: Value of the ``data.id`` query parameter. May be ``None``;
+                in that case the ``id:`` pair is omitted. When present, the
+                value is lowercased before being included in the manifest.
+            secret: Secret signature configured for the application in Tus
+                Integraciones.
+            tolerance_seconds: Optional maximum allowed drift in seconds
+                between the timestamp in the header and the current clock.
+                When ``None``, no timestamp check is performed.
+            supported_versions: Optional ordered iterable of signature versions
+                the validator will accept. Defaults to ``("v1",)``. The first
+                version found in the header is used.
+            now: Optional callable returning the current time in milliseconds
+                since the Unix epoch. Defaults to ``time.time() * 1000``.
+                Intended for tests.
+
+        Raises:
+            InvalidWebhookSignatureError: When the signature is missing,
+                malformed, or does not match the expected HMAC.
+            ValueError: When ``secret`` is ``None``.
+        """
+        if secret is None:
+            raise ValueError("secret must not be None")
+
+        x_signature = _normalize(x_signature)
+        x_request_id = _normalize(x_request_id)
+        data_id = _normalize(data_id)
+        versions = tuple(supported_versions) if supported_versions else _DEFAULT_SUPPORTED_VERSIONS
+        if now is None:
+            now = lambda: int(time.time() * 1000)
+
+        if x_signature is None:
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.MISSING_SIGNATURE_HEADER, x_request_id
+            )
+
+        ts, hashes = _parse_signature_header(x_signature)
+
+        if ts is None and not hashes:
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.MALFORMED_SIGNATURE_HEADER, x_request_id
+            )
+
+        if ts is None:
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.MISSING_TIMESTAMP, x_request_id
+            )
+
+        if not ts.isdigit():
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.MALFORMED_SIGNATURE_HEADER, x_request_id, ts
+            )
+
+        received_hash = None
+        for version in versions:
+            if version in hashes:
+                received_hash = hashes[version]
+                break
+
+        if received_hash is None:
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.MISSING_HASH, x_request_id, ts
+            )
+
+        manifest = _build_manifest(data_id, x_request_id, ts)
+        computed = hmac.new(
+            secret.encode("utf-8"), manifest.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        if not hmac.compare_digest(computed, received_hash):
+            raise InvalidWebhookSignatureError(
+                SignatureFailureReason.SIGNATURE_MISMATCH, x_request_id, ts
+            )
+
+        if tolerance_seconds is not None:
+            drift_ms = abs(now() - int(ts))
+            if drift_ms > tolerance_seconds * 1000:
+                raise InvalidWebhookSignatureError(
+                    SignatureFailureReason.TIMESTAMP_OUT_OF_TOLERANCE, x_request_id, ts
+                )
+
+
+def _normalize(value):
+    """Returns the trimmed string or ``None`` for missing/whitespace values."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _parse_signature_header(header):
+    """Parses the ``x-signature`` header into ``(ts, {vN: hash})``."""
+    hashes = {}
+    ts = None
+    for part in header.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if not key or not value:
+            continue
+        if key == "ts":
+            ts = value
+        elif _VERSION_KEY_REGEX.match(key):
+            hashes[key] = value
+    return ts, hashes
+
+
+def _build_manifest(data_id, request_id, ts):
+    """Builds the HMAC manifest, omitting empty pairs per the documented rule."""
+    parts = []
+    if data_id:
+        parts.append("id:{0}".format(data_id.lower()))
+    if request_id:
+        parts.append("request-id:{0}".format(request_id))
+    parts.append("ts:{0}".format(ts))
+    return ";".join(parts) + ";"

--- a/tests/test_webhook_signature_validator.py
+++ b/tests/test_webhook_signature_validator.py
@@ -1,0 +1,152 @@
+"""
+    Module: test_webhook_signature_validator
+
+Unit tests for :class:`mercadopago.webhook.WebhookSignatureValidator`.
+These tests are self-contained and do not require any environment variables
+or network access.
+"""
+import hashlib
+import hmac
+import time
+import unittest
+
+from mercadopago.webhook import (
+    InvalidWebhookSignatureError,
+    SignatureFailureReason,
+    WebhookSignatureValidator,
+)
+
+
+SECRET = "your_secret_key_here"
+REQUEST_ID = "2066ca19-c6f1-498a-be75-1923005edd06"
+DATA_ID_RAW = "ORD01JQ4S4KY8HWQ6NA5PXB65B3D3"
+DATA_ID_LOWER = "ord01jq4s4ky8hwq6na5pxb65b3d3"
+TS = "1742505638683"
+TS_NUM = int(TS)
+
+
+def compute_hash(data_id, request_id, ts, secret):
+    parts = []
+    if data_id:
+        parts.append("id:{0}".format(data_id.lower()))
+    if request_id:
+        parts.append("request-id:{0}".format(request_id))
+    parts.append("ts:{0}".format(ts))
+    manifest = ";".join(parts) + ";"
+    return hmac.new(secret.encode("utf-8"), manifest.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def build_header(h, ts=TS, version="v1"):
+    return "ts={0},{1}={2}".format(ts, version, h)
+
+
+VALID_HASH = compute_hash(DATA_ID_LOWER, REQUEST_ID, TS, SECRET)
+VALID_HEADER = build_header(VALID_HASH)
+
+
+class TestWebhookSignatureValidator(unittest.TestCase):
+    """Covers the 12 canonical cases plus supportedVersions and arg validation."""
+
+    # --- case 1 ---
+    def test_happy_path_lowercase(self):
+        WebhookSignatureValidator.validate(VALID_HEADER, REQUEST_ID, DATA_ID_LOWER, SECRET)
+
+    # --- case 2 ---
+    def test_uppercase_dataid_is_lowercased(self):
+        WebhookSignatureValidator.validate(VALID_HEADER, REQUEST_ID, DATA_ID_RAW, SECRET)
+
+    # --- case 3 ---
+    def test_malformed_header_raises_malformed(self):
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate("this-is-garbage", REQUEST_ID, DATA_ID_LOWER, SECRET)
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.MALFORMED_SIGNATURE_HEADER)
+        self.assertEqual(ctx.exception.request_id, REQUEST_ID)
+
+    # --- case 4 ---
+    def test_missing_header_raises_missing_header(self):
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate(None, REQUEST_ID, DATA_ID_LOWER, SECRET)
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.MISSING_SIGNATURE_HEADER)
+
+    # --- case 5 ---
+    def test_missing_ts_raises_missing_timestamp(self):
+        header = "v1={0}".format(VALID_HASH)
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate(header, REQUEST_ID, DATA_ID_LOWER, SECRET)
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.MISSING_TIMESTAMP)
+
+    # --- case 6 ---
+    def test_missing_v1_raises_missing_hash(self):
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate("ts={0}".format(TS), REQUEST_ID, DATA_ID_LOWER, SECRET)
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.MISSING_HASH)
+        self.assertEqual(ctx.exception.timestamp, TS)
+
+    # --- case 7 ---
+    def test_tampered_hash_raises_signature_mismatch(self):
+        tampered = VALID_HASH[:-2] + ("ff" if VALID_HASH.endswith("00") else "00")
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate(build_header(tampered), REQUEST_ID, DATA_ID_LOWER, SECRET)
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.SIGNATURE_MISMATCH)
+
+    # --- case 8 ---
+    def test_timestamp_outside_tolerance_raises(self):
+        stale_ts = str(int(time.time() * 1000) - 30 * 60 * 1000)
+        h = compute_hash(DATA_ID_LOWER, REQUEST_ID, stale_ts, SECRET)
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate(
+                build_header(h, stale_ts), REQUEST_ID, DATA_ID_LOWER, SECRET,
+                tolerance_seconds=300,
+            )
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.TIMESTAMP_OUT_OF_TOLERANCE)
+
+    def test_timestamp_within_tolerance_passes(self):
+        current_ts = str(int(time.time() * 1000))
+        h = compute_hash(DATA_ID_LOWER, REQUEST_ID, current_ts, SECRET)
+        WebhookSignatureValidator.validate(
+            build_header(h, current_ts), REQUEST_ID, DATA_ID_LOWER, SECRET,
+            tolerance_seconds=300,
+        )
+
+    # --- case 9 ---
+    def test_dataid_absent_excludes_id_pair(self):
+        h = compute_hash(None, REQUEST_ID, TS, SECRET)
+        WebhookSignatureValidator.validate(build_header(h), REQUEST_ID, None, SECRET)
+
+    # --- case 10 ---
+    def test_request_id_absent_excludes_request_id_pair(self):
+        h = compute_hash(DATA_ID_LOWER, None, TS, SECRET)
+        WebhookSignatureValidator.validate(build_header(h), None, DATA_ID_LOWER, SECRET)
+
+    # --- case 11 ---
+    def test_both_absent_yields_ts_only(self):
+        h = compute_hash(None, None, TS, SECRET)
+        WebhookSignatureValidator.validate(build_header(h), "", "  ", SECRET)
+
+    # --- case 12 ---
+    def test_non_payment_topic_uses_same_algorithm(self):
+        order_id = "ord01abc123"
+        h = compute_hash(order_id, REQUEST_ID, TS, SECRET)
+        WebhookSignatureValidator.validate(build_header(h), REQUEST_ID, order_id, SECRET)
+
+    # --- supportedVersions ---
+    def test_supports_v1_when_both_present(self):
+        header = "ts={0},v1={1},v2=aaaa".format(TS, VALID_HASH)
+        WebhookSignatureValidator.validate(header, REQUEST_ID, DATA_ID_LOWER, SECRET,
+                                           supported_versions=["v1"])
+
+    def test_only_v2_in_header_only_v1_supported_raises_missing_hash(self):
+        header = "ts={0},v2=somehash".format(TS)
+        with self.assertRaises(InvalidWebhookSignatureError) as ctx:
+            WebhookSignatureValidator.validate(header, REQUEST_ID, DATA_ID_LOWER, SECRET,
+                                               supported_versions=["v1"])
+        self.assertEqual(ctx.exception.reason, SignatureFailureReason.MISSING_HASH)
+
+    # --- secret null guard ---
+    def test_null_secret_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            WebhookSignatureValidator.validate(VALID_HEADER, REQUEST_ID, DATA_ID_LOWER, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a stateless utility to verify the authenticity of incoming MercadoPago webhook notifications by recomputing the HMAC-SHA256 signature and comparing it against the `x-signature` header in constant time (timing-attack safe).

## Changes
- `mercadopago/webhook/validator.py`: HMAC-SHA256 validator with explicit secret per call, typed failure reasons
- `mercadopago/webhook/__init__.py`: package init exporting the validator
- `tests/test_webhook_signature_validator.py`: unit tests covering success, malformed inputs, timestamp window, hash mismatch

## Test plan
- [ ] CI green