### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/mercadopago/webhook/validator.py
+++ b/mercadopago/webhook/validator.py
@@ -105,7 +105,7 @@ class WebhookSignatureValidator:  # pylint: disable=too-few-public-methods
                 the manifest before computing the HMAC.
             data_id: Value of the ``data.id`` query parameter. May be ``None``;
                 in that case the ``id:`` pair is omitted. When present, the
-                value is lowercased before being included in the manifest.
+                value is included in the manifest exactly as received.
             secret: Secret signature configured for the application in Tus
                 Integraciones.
             tolerance_seconds: Optional maximum allowed drift in seconds
@@ -216,7 +216,7 @@ def _build_manifest(data_id, request_id, ts):
     """Builds the HMAC manifest, omitting empty pairs per the documented rule."""
     parts = []
     if data_id:
-        parts.append(f"id:{data_id.lower()}")
+        parts.append(f"id:{data_id}")
     if request_id:
         parts.append(f"request-id:{request_id}")
     parts.append(f"ts:{ts}")

--- a/tests/test_webhook_signature_validator.py
+++ b/tests/test_webhook_signature_validator.py
@@ -28,7 +28,7 @@ TS_NUM = int(TS)
 def compute_hash(data_id, request_id, ts, secret):
     parts = []
     if data_id:
-        parts.append(f"id:{data_id.lower()}")
+        parts.append(f"id:{data_id}")
     if request_id:
         parts.append(f"request-id:{request_id}")
     parts.append(f"ts:{ts}")
@@ -52,8 +52,10 @@ class TestWebhookSignatureValidator(unittest.TestCase):
         WebhookSignatureValidator.validate(VALID_HEADER, REQUEST_ID, DATA_ID_LOWER, SECRET)
 
     # --- case 2 ---
-    def test_uppercase_dataid_is_lowercased(self):
-        WebhookSignatureValidator.validate(VALID_HEADER, REQUEST_ID, DATA_ID_RAW, SECRET)
+    def test_uppercase_dataid_is_preserved(self):
+        upper_hash = compute_hash(DATA_ID_RAW, REQUEST_ID, TS, SECRET)
+        upper_header = build_header(upper_hash)
+        WebhookSignatureValidator.validate(upper_header, REQUEST_ID, DATA_ID_RAW, SECRET)
 
     # --- case 3 ---
     def test_malformed_header_raises_malformed(self):


### PR DESCRIPTION
## Problem

The `WebhookSignatureValidator` was calling `.lower()` on `data_id` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `.lower()` call in `_build_manifest` so the value is included exactly as received. The docstring is updated accordingly.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing.