### PR TITLE
Add industry fields to preference examples and payment tests

### DIFF
--- a/mercadopago/examples/preference/create_preference.py
+++ b/mercadopago/examples/preference/create_preference.py
@@ -1,5 +1,6 @@
 from mercadopago.sdk import SDK
 
+
 def main():
     # Define the authentication token
     access_token = "<YOUR_ACCESS_TOKEN>"
@@ -11,9 +12,51 @@ def main():
                 {
                     "title": "Dummy Item",
                     "quantity": 1,
-                    "unit_price": 10.0
+                    "unit_price": 10.0,
+                    "warranty": False,
+                    "type": "default",
+                    "event_date": "2027-01-15T00:00:00.000-03:00",
+                    "category_descriptor": {
+                        "passenger": {
+                            "first_name": "<PASSENGER_FIRST_NAME>",
+                            "last_name": "<PASSENGER_LAST_NAME>",
+                            "identification": {
+                                "type": "CPF",
+                                "number": "<PASSENGER_DOC_NUMBER>"
+                            }
+                        },
+                        "route": {
+                            "departure": "SAO",
+                            "destination": "RIO",
+                            "departure_date_time": "2027-01-15T08:00:00.000-03:00",
+                            "arrival_date_time": "2027-01-15T09:00:00.000-03:00",
+                            "company": "TAM"
+                        }
+                    }
                 }
             ],
+            "payer": {
+                "email": "<PAYER_EMAIL>",
+                "date_created": "2020-01-15T00:00:00.000-03:00",
+                "authentication_type": "MOBILE",
+                "is_prime_user": False,
+                "is_first_purchase_online": False,
+                "last_purchase": "2025-12-01T00:00:00.000-03:00",
+                "registration_date": "2020-01-15T00:00:00.000-03:00"
+            },
+            "shipments": {
+                "receiver_address": {
+                    "street_name": "Av. Paulista",
+                    "street_number": 1000,
+                    "zip_code": "01310-100",
+                    "state_name": "Sao Paulo",
+                    "city_name": "Sao Paulo",
+                    "floor": "3",
+                    "apartment": "B"
+                },
+                "express_shipment": False,
+                "local_pickup": False
+            },
             "notification_url": "https://webhook.site/test-notification"
         }
 
@@ -22,6 +65,7 @@ def main():
         print(preference)
     except Exception as e:
         print("Error:", e)
+
 
 if __name__ == "__main__":
     main()

--- a/mercadopago/examples/preference/create_with_industry_fields.py
+++ b/mercadopago/examples/preference/create_with_industry_fields.py
@@ -1,0 +1,132 @@
+# Example: Preference with industry data fields for payment approval improvement
+from mercadopago.sdk import SDK
+
+
+def main():
+    # Define the authentication token
+    access_token = "<YOUR_ACCESS_TOKEN>"
+    sdk = SDK(access_token)
+
+    try:
+        preference_data = {
+            "items": [
+                {
+                    "id": "FLIGHT-001",
+                    "title": "Flight SAO-RIO",
+                    "description": "Round trip, economy class",
+                    "picture_url": "https://example.com/flight.jpg",
+                    "category_id": "travels",
+                    "quantity": 1,
+                    "currency_id": "BRL",
+                    "unit_price": 450.00,
+                    "warranty": False,
+                    "type": "travel",
+                    "event_date": "2027-01-15T08:00:00.000-03:00",
+                    "category_descriptor": {
+                        "passenger": {
+                            "first_name": "<PASSENGER_FIRST_NAME>",
+                            "last_name": "<PASSENGER_LAST_NAME>",
+                            "identification": {
+                                "type": "CPF",
+                                "number": "<PASSENGER_DOC_NUMBER>"
+                            }
+                        },
+                        "route": {
+                            "departure": "SAO",
+                            "destination": "RIO",
+                            "departure_date_time": "2027-01-15T08:00:00.000-03:00",
+                            "arrival_date_time": "2027-01-15T09:00:00.000-03:00",
+                            "company": "TAM"
+                        }
+                    }
+                },
+                {
+                    "id": "INSURANCE-001",
+                    "title": "Travel Insurance",
+                    "description": "Basic coverage during trip",
+                    "picture_url": "https://example.com/insurance.jpg",
+                    "category_id": "travels",
+                    "quantity": 1,
+                    "currency_id": "BRL",
+                    "unit_price": 50.00,
+                    "warranty": True,
+                    "type": "travel",
+                    "event_date": "2027-01-15T08:00:00.000-03:00",
+                    "category_descriptor": {
+                        "passenger": {
+                            "first_name": "<PASSENGER_FIRST_NAME>",
+                            "last_name": "<PASSENGER_LAST_NAME>",
+                            "identification": {
+                                "type": "CPF",
+                                "number": "<PASSENGER_DOC_NUMBER>"
+                            }
+                        },
+                        "route": {
+                            "departure": "SAO",
+                            "destination": "RIO",
+                            "departure_date_time": "2027-01-15T08:00:00.000-03:00",
+                            "arrival_date_time": "2027-01-15T09:00:00.000-03:00",
+                            "company": "TAM"
+                        }
+                    }
+                }
+            ],
+            "payer": {
+                "email": "<PAYER_EMAIL>",
+                "name": "<PAYER_FIRST_NAME>",
+                "surname": "<PAYER_LAST_NAME>",
+                "date_created": "2020-01-15T00:00:00.000-03:00",
+                "authentication_type": "MOBILE",
+                "is_prime_user": True,
+                "is_first_purchase_online": False,
+                "last_purchase": "2025-12-01T00:00:00.000-03:00",
+                "registration_date": "2020-01-15T00:00:00.000-03:00",
+                "phone": {
+                    "area_code": "11",
+                    "number": "999998888"
+                },
+                "identification": {
+                    "type": "CPF",
+                    "number": "<PAYER_DOC_NUMBER>"
+                },
+                "address": {
+                    "zip_code": "01310-100",
+                    "street_name": "Av. Paulista",
+                    "street_number": "1000"
+                }
+            },
+            "shipments": {
+                "mode": "custom",
+                "receiver_address": {
+                    "street_name": "Av. Paulista",
+                    "street_number": "1000",
+                    "zip_code": "01310-100",
+                    "state_name": "Sao Paulo",
+                    "city_name": "Sao Paulo",
+                    "floor": "3",
+                    "apartment": "B"
+                },
+                "express_shipment": False,
+                "local_pickup": False
+            },
+            "back_urls": {
+                "success": "https://example.com/success",
+                "failure": "https://example.com/failure",
+                "pending": "https://example.com/pending"
+            },
+            "auto_return": "approved",
+            "external_reference": "TRAVEL-BOOKING-001",
+            "notification_url": "https://example.com/notifications"
+        }
+
+        # Call the method to create the preference
+        preference = sdk.preference().create(preference_data)
+        print("Preference created successfully:")
+        print("id:", preference["response"].get("id"))
+        print("init_point:", preference["response"].get("init_point"))
+    except Exception as e:
+        print("Error:", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -71,6 +71,14 @@ class TestPayment(unittest.TestCase):
                         "street_number": 3003
                     },
                     "registration_date": "2019-01-01T12:01:01.000-03:00",
+                    "authentication_type": "WEB",
+                    "is_prime_user": False,
+                    "is_first_purchase_online": False,
+                    "last_purchase": "2024-01-01T12:01:01.000-03:00",
+                    "identification": {
+                        "type": "CPF",
+                        "number": "19119119100"
+                    },
                     "phone": {
                         "area_code": "011",
                         "number": "987654321"

--- a/tests/test_preference.py
+++ b/tests/test_preference.py
@@ -26,9 +26,51 @@ class TestPreference(unittest.TestCase):
                     "quantity": 1,
                     "title": "Item 1",
                     "currency_id": "BRL",
-                    "unit_price": 20.5
+                    "unit_price": 20.5,
+                    "warranty": False,
+                    "type": "default",
+                    "event_date": "2027-01-15T00:00:00.000-03:00",
+                    "category_descriptor": {
+                        "passenger": {
+                            "first_name": "Nome",
+                            "last_name": "Sobrenome",
+                            "identification": {
+                                "type": "CPF",
+                                "number": "19119119100"
+                            }
+                        },
+                        "route": {
+                            "departure": "SAO",
+                            "destination": "RIO",
+                            "departure_date_time": "2027-01-15T08:00:00.000-03:00",
+                            "arrival_date_time": "2027-01-15T09:00:00.000-03:00",
+                            "company": "TAM"
+                        }
+                    }
                 }
-            ]
+            ],
+            "payer": {
+                "email": "test_user_123456@testuser.com",
+                "date_created": "2020-01-15T00:00:00.000-03:00",
+                "authentication_type": "WEB",
+                "is_prime_user": False,
+                "is_first_purchase_online": False,
+                "last_purchase": "2024-01-01T00:00:00.000-03:00",
+                "registration_date": "2020-01-15T00:00:00.000-03:00"
+            },
+            "shipments": {
+                "receiver_address": {
+                    "street_name": "Av das Nacoes Unidas",
+                    "street_number": 3003,
+                    "zip_code": "06233200",
+                    "state_name": "Rio de Janeiro",
+                    "city_name": "Buzios",
+                    "floor": "2",
+                    "apartment": "A"
+                },
+                "express_shipment": False,
+                "local_pickup": False
+            }
         }
         preference_saved = self.sdk.preference().create(preference_object)
         self.assertEqual(preference_saved["status"], 201)


### PR DESCRIPTION
Update create_preference.py and tests to include all industry data fields: payer authentication_type, is_prime_user, is_first_purchase_online, last_purchase, registration_date; item warranty, type, event_date, category_descriptor with passenger and route; shipment receiver address fields and express_shipment/local_pickup.

Add new example create_with_industry_fields.py for travel/hospitality use case demonstrating full industry data payload.