### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/mercadopago/core/mp_base.py
+++ b/mercadopago/core/mp_base.py
@@ -5,6 +5,7 @@ Customer, etc.) inherits.  Handles request-option merging, header
 construction, JSON encoding, and delegation to the configured HTTP client.
 """
 from json.encoder import JSONEncoder
+from urllib.parse import quote
 
 from mercadopago.config.config import Config
 from mercadopago.config.request_options import RequestOptions
@@ -78,6 +79,10 @@ class MPBase:
             headers.update(extra_headers)
 
         return headers
+
+    def _path_param(self, value):
+        """Encodes a dynamic URL path segment."""
+        return quote(str(value), safe="")
 
     def _get(self, uri, filters=None, request_options=None):
         """Performs an authenticated GET request.

--- a/mercadopago/resources/advanced_payment.py
+++ b/mercadopago/resources/advanced_payment.py
@@ -46,7 +46,7 @@ class AdvancedPayment(MPBase):
         Returns:
             dict: Full advanced payment object.
         """
-        return self._get(uri="/v1/advanced_payments/" + str(advanced_payment_id),
+        return self._get(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id),
                          request_options=request_options)
 
     def create(self, advanced_payment_object, request_options=None):
@@ -83,7 +83,7 @@ class AdvancedPayment(MPBase):
             dict: Captured advanced payment with updated status.
         """
         capture_object = {"capture": True}
-        return self._put(uri="/v1/advanced_payments/" + str(advanced_payment_id),
+        return self._put(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id),
                          data=capture_object, request_options=request_options)
 
     def update(self, advanced_payment_id, advanced_payment_object, request_options=None):
@@ -104,7 +104,7 @@ class AdvancedPayment(MPBase):
             raise ValueError(
                 "Param advanced_payment_object must be a Dictionary")
 
-        return self._put(uri="/v1/advanced_payments/" + str(advanced_payment_id),
+        return self._put(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id),
                          data=advanced_payment_object, request_options=request_options)
 
     def cancel(self, advanced_payment_id, request_options=None):
@@ -121,7 +121,7 @@ class AdvancedPayment(MPBase):
             dict: Cancelled advanced payment with updated status.
         """
         cancel_object = {"status": "cancelled"}
-        return self._put(uri="/v1/advanced_payments/" + str(advanced_payment_id),
+        return self._put(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id),
                          data=cancel_object, request_options=request_options)
 
     def update_release_date(self, advanced_payment_id, release_date, request_options=None):
@@ -147,5 +147,5 @@ class AdvancedPayment(MPBase):
         disbursement_object = {
             "money_release_date": release_date.strftime("%Y-%m-%d %H:%M:%S.%f")}
 
-        return self._post(uri="/v1/advanced_payments/" + str(advanced_payment_id) + "/disburses",
+        return self._post(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id) + "/disburses",
                           data=disbursement_object, request_options=request_options)

--- a/mercadopago/resources/card.py
+++ b/mercadopago/resources/card.py
@@ -1,6 +1,6 @@
 """Saved-card resource for the MercadoPago API.
 
-Wraps ``/v1/customers/{customer_id}/cards`` endpoints to list, retrieve,
+Wraps ``/v1/customers/{self._path_param(customer_id)}/cards`` endpoints to list, retrieve,
 create, update, and delete cards stored against a customer profile.
 
 `API reference <https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/save-card/post>`_
@@ -29,7 +29,7 @@ class Card(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-customer-cards/get
         """
         return self._get(
-            uri=f"/v1/customers/{str(customer_id)}/cards",
+            uri=f"/v1/customers/{self._path_param(customer_id)}/cards",
             request_options=request_options,
         )
 
@@ -47,7 +47,7 @@ class Card(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/get-card/get
         """
         return self._get(
-            uri=f"/v1/customers/{str(customer_id)}/cards/{str(card_id)}",
+            uri=f"/v1/customers/{self._path_param(customer_id)}/cards/{self._path_param(card_id)}",
             request_options=request_options,
         )
 
@@ -73,7 +73,7 @@ class Card(MPBase):
         if not isinstance(card_object, dict):
             raise ValueError("Param card_object must be a Dictionary")
 
-        return self._post(uri="/v1/customers/" + str(customer_id)
+        return self._post(uri="/v1/customers/" + self._path_param(customer_id)
                           + "/cards/", data=card_object, request_options=request_options)
 
     def update(self, customer_id, card_id, card_object, request_options=None):
@@ -96,8 +96,8 @@ class Card(MPBase):
         if not isinstance(card_object, dict):
             raise ValueError("Param card_object must be a Dictionary")
 
-        return self._put(uri="/v1/customers/" + str(customer_id)
-                         + "/cards/" + str(card_id), data=card_object,
+        return self._put(uri="/v1/customers/" + self._path_param(customer_id)
+                         + "/cards/" + self._path_param(card_id), data=card_object,
                          request_options=request_options)
 
     def delete(self, customer_id, card_id, request_options=None):
@@ -113,5 +113,5 @@ class Card(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/delete-card/delete
         """
-        return self._delete(uri="/v1/customers/" + str(customer_id)
-                            + "/cards/" + str(card_id), request_options=request_options)
+        return self._delete(uri="/v1/customers/" + self._path_param(customer_id)
+                            + "/cards/" + self._path_param(card_id), request_options=request_options)

--- a/mercadopago/resources/card_token.py
+++ b/mercadopago/resources/card_token.py
@@ -25,7 +25,7 @@ class CardToken(MPBase):
         Returns:
             dict: Token metadata (last four digits, expiry, etc.).
         """
-        return self._get(uri="/v1/card_tokens/" + str(card_token_id),
+        return self._get(uri="/v1/card_tokens/" + self._path_param(card_token_id),
                          request_options=request_options)
 
     def create(self, card_token_object, request_options=None):

--- a/mercadopago/resources/chargeback.py
+++ b/mercadopago/resources/chargeback.py
@@ -40,5 +40,5 @@ class Chargeback(MPBase):
         Returns:
             dict: Full chargeback object including status and amounts.
         """
-        return self._get(uri="/v1/chargebacks/" + str(chargeback_id),
+        return self._get(uri="/v1/chargebacks/" + self._path_param(chargeback_id),
                          request_options=request_options)

--- a/mercadopago/resources/customer.py
+++ b/mercadopago/resources/customer.py
@@ -44,7 +44,7 @@ class Customer(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/get-customer/get
         """
-        return self._get(uri="/v1/customers/" + str(customer_id), request_options=request_options)
+        return self._get(uri="/v1/customers/" + self._path_param(customer_id), request_options=request_options)
 
     def create(self, customer_object, request_options=None):
         """Creates a new customer record.
@@ -87,7 +87,7 @@ class Customer(MPBase):
         if not isinstance(customer_object, dict):
             raise ValueError("Param customer_object must be a Dictionary")
 
-        return self._put(uri="/v1/customers/" + str(customer_id), data=customer_object,
+        return self._put(uri="/v1/customers/" + self._path_param(customer_id), data=customer_object,
                          request_options=request_options)
 
     def delete(self, customer_id, request_options=None):
@@ -102,5 +102,5 @@ class Customer(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/get-customer/get
         """
-        return self._delete(uri="/v1/customers/" + str(customer_id),
+        return self._delete(uri="/v1/customers/" + self._path_param(customer_id),
                             request_options=request_options)

--- a/mercadopago/resources/disbursement_refund.py
+++ b/mercadopago/resources/disbursement_refund.py
@@ -25,7 +25,7 @@ class DisbursementRefund(MPBase):
         Returns:
             dict: List of disbursement refund objects.
         """
-        uri = f"/v1/advanced_payments/{str(advanced_payment_id)}/refunds"
+        uri = f"/v1/advanced_payments/{self._path_param(advanced_payment_id)}/refunds"
         return self._get(uri=uri, request_options=request_options)
 
     def create_all(self, advanced_payment_id, disbursement_refund_object, request_options=None):
@@ -48,7 +48,7 @@ class DisbursementRefund(MPBase):
                 "Param disbursement_refund_object must be a Dictionary")
 
         return self._post(
-            uri="/v1/advanced_payments/" + str(advanced_payment_id) + "/refunds",
+            uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id) + "/refunds",
             data=disbursement_refund_object,
             request_options=request_options,
         )
@@ -74,8 +74,8 @@ class DisbursementRefund(MPBase):
         disbursement_refund_object = {"amount": amount}
 
         uri = (
-            f"/v1/advanced_payments/{str(advanced_payment_id)}"
-            f"/disbursements/{str(disbursement_id)}/refunds"
+            f"/v1/advanced_payments/{self._path_param(advanced_payment_id)}"
+            f"/disbursements/{self._path_param(disbursement_id)}/refunds"
         )
 
         return self._post(
@@ -108,8 +108,8 @@ class DisbursementRefund(MPBase):
                 "Param disbursement_refund_object must be a Dictionary")
 
         uri = (
-            f"/v1/advanced_payments/{str(advanced_payment_id)}"
-            f"/disbursements/{str(disbursement_id)}/refunds"
+            f"/v1/advanced_payments/{self._path_param(advanced_payment_id)}"
+            f"/disbursements/{self._path_param(disbursement_id)}/refunds"
         )
 
         return self._post(

--- a/mercadopago/resources/invoice.py
+++ b/mercadopago/resources/invoice.py
@@ -37,7 +37,7 @@ class Invoice(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-authorized-payment/get
         """
         return self._get(
-            uri="/authorized_payments/" + str(invoice_id),
+            uri="/authorized_payments/" + self._path_param(invoice_id),
             request_options=request_options,
         )
 

--- a/mercadopago/resources/merchant_order.py
+++ b/mercadopago/resources/merchant_order.py
@@ -45,7 +45,7 @@ class MerchantOrder(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/merchant_orders/get-merchant-order/get
         """
-        return self._get(uri="/merchant_orders/" + str(merchan_order_id),
+        return self._get(uri="/merchant_orders/" + self._path_param(merchan_order_id),
                          request_options=request_options)
 
     def update(self, merchan_order_id, merchant_order_object, request_options=None):
@@ -68,7 +68,7 @@ class MerchantOrder(MPBase):
             raise ValueError(
                 "Param merchant_order_object must be a Dictionary")
 
-        return self._put(uri="/merchant_orders/" + str(merchan_order_id),
+        return self._put(uri="/merchant_orders/" + self._path_param(merchan_order_id),
                          data=merchant_order_object, request_options=request_options)
 
     def create(self, merchant_order_object, request_options=None):

--- a/mercadopago/resources/order.py
+++ b/mercadopago/resources/order.py
@@ -125,7 +125,7 @@ class Order(MPBase):
         if not isinstance(order_id, str):
             raise ValueError("Param order_id must be a string")
 
-        return self._get(uri="/v1/orders/" + str(order_id), request_options=request_options)
+        return self._get(uri="/v1/orders/" + self._path_param(order_id), request_options=request_options)
 
     def process(self, order_id, request_options=None):
         """Processes (executes payment for) an existing order.
@@ -150,7 +150,7 @@ class Order(MPBase):
             raise ValueError("Param order_id must be a string")
 
         return self._post(
-            uri=f"/v1/orders/{order_id}/process",
+            uri=f"/v1/orders/{self._path_param(order_id)}/process",
             request_options=request_options,
         )
 
@@ -175,7 +175,7 @@ class Order(MPBase):
             raise ValueError("Param order_id must be a string")
 
         return self._post(
-            uri=f"/v1/orders/{order_id}/cancel",
+            uri=f"/v1/orders/{self._path_param(order_id)}/cancel",
             request_options=request_options,
         )
 
@@ -202,7 +202,7 @@ class Order(MPBase):
             raise ValueError("Param order_id must be a string")
 
         return self._post(
-            uri=f"/v1/orders/{order_id}/capture",
+            uri=f"/v1/orders/{self._path_param(order_id)}/capture",
             request_options=request_options,
         )
 
@@ -225,7 +225,7 @@ class Order(MPBase):
         if not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._post(uri=f"/v1/orders/{order_id}/transactions", data=transaction_object,
+        return self._post(uri=f"/v1/orders/{self._path_param(order_id)}/transactions", data=transaction_object,
                           request_options=request_options)
 
     def update_transaction(
@@ -249,7 +249,7 @@ class Order(MPBase):
         if not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._put(uri=f"/v1/orders/{order_id}/transactions/{transaction_id}",
+        return self._put(uri=f"/v1/orders/{self._path_param(order_id)}/transactions/{self._path_param(transaction_id)}",
                          data=transaction_object, request_options=request_options)
 
     def refund_transaction(self, order_id, transaction_object=None, request_options=None):
@@ -275,7 +275,7 @@ class Order(MPBase):
         if transaction_object is not None and not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._post(uri=f"/v1/orders/{order_id}/refund", data=transaction_object,
+        return self._post(uri=f"/v1/orders/{self._path_param(order_id)}/refund", data=transaction_object,
                           request_options=request_options)
 
     def refund(self, order_id, refund_object=None, request_options=None):
@@ -315,5 +315,5 @@ class Order(MPBase):
         if not isinstance(order_id, str) or not isinstance(transaction_id, str):
             raise ValueError("Params order_id and transaction_id must be strings")
 
-        return self._delete(uri=f"/v1/orders/{order_id}/transactions/{transaction_id}",
+        return self._delete(uri=f"/v1/orders/{self._path_param(order_id)}/transactions/{self._path_param(transaction_id)}",
                             request_options=request_options)

--- a/mercadopago/resources/payment.py
+++ b/mercadopago/resources/payment.py
@@ -46,7 +46,7 @@ class Payment(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-payment/get
         """
-        return self._get(uri="/v1/payments/" + str(payment_id), request_options=request_options)
+        return self._get(uri="/v1/payments/" + self._path_param(payment_id), request_options=request_options)
 
     def create(self, payment_object, request_options=None):
         """Creates a new payment.
@@ -91,5 +91,5 @@ class Payment(MPBase):
         if not isinstance(payment_object, dict):
             raise ValueError("Param payment_object must be a Dictionary")
 
-        return self._put(uri="/v1/payments/" + str(payment_id), data=payment_object,
+        return self._put(uri="/v1/payments/" + self._path_param(payment_id), data=payment_object,
                          request_options=request_options)

--- a/mercadopago/resources/plan.py
+++ b/mercadopago/resources/plan.py
@@ -48,7 +48,7 @@ class Plan(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval-plan/get
         """
         return self._get(
-            uri="/preapproval_plan/" + str(plan_id),
+            uri="/preapproval_plan/" + self._path_param(plan_id),
             request_options=request_options)
 
     def create(self, plan_object, request_options=None):
@@ -95,6 +95,6 @@ class Plan(MPBase):
             raise ValueError("Param plan_object must be a Dictionary")
 
         return self._put(
-            uri="/preapproval_plan/" + str(plan_id),
+            uri="/preapproval_plan/" + self._path_param(plan_id),
             data=plan_object,
             request_options=request_options)

--- a/mercadopago/resources/point.py
+++ b/mercadopago/resources/point.py
@@ -7,7 +7,7 @@ Supported operations: list devices, create payment intent, get payment
 intent, and cancel payment intent.
 
 Note: The ``change_operating_mode`` operation (PATCH
-``/point/integration-api/devices/{device_id}``) is not included because
+``/point/integration-api/devices/{self._path_param(device_id)}``) is not included because
 the Python SDK HTTP client does not currently expose a PATCH method.
 
 `API reference
@@ -70,7 +70,7 @@ class Point(MPBase):
             raise ValueError("Param payment_intent_object must be a Dictionary")
 
         return self._post(
-            uri="/point/integration-api/devices/" + str(device_id) + "/payment-intents",
+            uri="/point/integration-api/devices/" + self._path_param(device_id) + "/payment-intents",
             data=payment_intent_object,
             request_options=request_options,
         )
@@ -92,7 +92,7 @@ class Point(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/in-person-payments/point/orders/get-order/get
         """
         return self._get(
-            uri="/point/integration-api/payment-intents/" + str(payment_intent_id),
+            uri="/point/integration-api/payment-intents/" + self._path_param(payment_intent_id),
             request_options=request_options,
         )
 
@@ -115,7 +115,7 @@ class Point(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/in-person-payments/point/orders/cancel-order/post
         """
         return self._delete(
-            uri="/point/integration-api/devices/" + str(device_id)
-                + "/payment-intents/" + str(payment_intent_id),
+            uri="/point/integration-api/devices/" + self._path_param(device_id)
+                + "/payment-intents/" + self._path_param(payment_intent_id),
             request_options=request_options,
         )

--- a/mercadopago/resources/preapproval.py
+++ b/mercadopago/resources/preapproval.py
@@ -46,7 +46,7 @@ class PreApproval(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval/get
         """
-        return self._get(uri="/preapproval/" + str(preapproval_id), request_options=request_options)
+        return self._get(uri="/preapproval/" + self._path_param(preapproval_id), request_options=request_options)
 
     def create(self, preapproval_object, request_options=None):
         """Creates a new preapproval (ad-hoc subscription).
@@ -89,5 +89,5 @@ class PreApproval(MPBase):
         if not isinstance(preapproval_object, dict):
             raise ValueError("Param preapproval_object must be a Dictionary")
 
-        return self._put(uri="/preapproval/" + str(preapproval_id),
+        return self._put(uri="/preapproval/" + self._path_param(preapproval_id),
                          data=preapproval_object, request_options=request_options)

--- a/mercadopago/resources/preference.py
+++ b/mercadopago/resources/preference.py
@@ -28,7 +28,7 @@ class Preference(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-pro/preferences/get-preference/get
         """
-        return self._get(uri="/checkout/preferences/" + str(preference_id),
+        return self._get(uri="/checkout/preferences/" + self._path_param(preference_id),
                          request_options=request_options)
 
     def update(self, preference_id, preference_object, request_options=None):
@@ -50,7 +50,7 @@ class Preference(MPBase):
         if not isinstance(preference_object, dict):
             raise ValueError("Param preference_object must be a Dictionary")
 
-        return self._put(uri="/checkout/preferences/" + str(preference_id), data=preference_object,
+        return self._put(uri="/checkout/preferences/" + self._path_param(preference_id), data=preference_object,
                          request_options=request_options)
 
     def create(self, preference_object, request_options=None):

--- a/mercadopago/resources/refund.py
+++ b/mercadopago/resources/refund.py
@@ -1,6 +1,6 @@
 """Refund resource for the MercadoPago Payments API.
 
-Wraps ``/v1/payments/{payment_id}/refunds`` endpoints to list existing
+Wraps ``/v1/payments/{self._path_param(payment_id)}/refunds`` endpoints to list existing
 refunds and create full or partial refunds on approved payments.
 
 Refunds are available within 180 days of payment approval and require
@@ -31,7 +31,7 @@ class Refund(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-refunds/get
         """
-        return self._get(uri="/v1/payments/" + str(payment_id) + "/refunds",
+        return self._get(uri="/v1/payments/" + self._path_param(payment_id) + "/refunds",
                          request_options=request_options)
 
     def create(self, payment_id, refund_object=None, request_options=None):
@@ -56,5 +56,5 @@ class Refund(MPBase):
         if refund_object is not None and not isinstance(refund_object, dict):
             raise ValueError("Param refund_object must be a Dictionary")
 
-        return self._post(uri="/v1/payments/" + str(payment_id) + "/refunds",
+        return self._post(uri="/v1/payments/" + self._path_param(payment_id) + "/refunds",
                           data=refund_object, request_options=request_options)

--- a/mercadopago/resources/subscription.py
+++ b/mercadopago/resources/subscription.py
@@ -49,7 +49,7 @@ class Subscription(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval/get
         """
         return self._get(
-            uri="/preapproval/" + str(subscription_id),
+            uri="/preapproval/" + self._path_param(subscription_id),
             request_options=request_options)
 
     def create(self, subscription_object, request_options=None):
@@ -99,6 +99,6 @@ class Subscription(MPBase):
             raise ValueError("Param subscription_object must be a Dictionary")
 
         return self._put(
-            uri="/preapproval/" + str(subscription_id),
+            uri="/preapproval/" + self._path_param(subscription_id),
             data=subscription_object,
             request_options=request_options)

--- a/tests/test_path_param.py
+++ b/tests/test_path_param.py
@@ -1,0 +1,18 @@
+import unittest
+
+from mercadopago.config.request_options import RequestOptions
+from mercadopago.core import MPBase
+
+
+class TestPathParam(unittest.TestCase):
+    def test_path_param_escapes_path_traversal(self):
+        base = MPBase(RequestOptions(access_token="token"), None)
+
+        self.assertEqual(
+            "..%2F..%2Fapplications%2F123",
+            base._path_param("../../applications/123"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a shared path-parameter encoder in MPBase.
- Applies encoding to dynamic IDs across affected resources.
- Adds regression coverage for traversal-style path parameters.

## Validation
- `python3 -m unittest tests/test_path_param.py`