### PR TITLE
Pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7
 
       # Sets up python
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v7
         with:
           python-version: 3.12
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip "setuptools>=83.0.0"
         python -m pip install requests
 
     - name: Lint with Pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v7
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/mercadopago/resources/advanced_payment.py
+++ b/mercadopago/resources/advanced_payment.py
@@ -147,5 +147,10 @@ class AdvancedPayment(MPBase):
         disbursement_object = {
             "money_release_date": release_date.strftime("%Y-%m-%d %H:%M:%S.%f")}
 
-        return self._post(uri="/v1/advanced_payments/" + self._path_param(advanced_payment_id) + "/disburses",
-                          data=disbursement_object, request_options=request_options)
+        return self._post(
+            uri="/v1/advanced_payments/"
+            + self._path_param(advanced_payment_id)
+            + "/disburses",
+            data=disbursement_object,
+            request_options=request_options,
+        )

--- a/mercadopago/resources/card.py
+++ b/mercadopago/resources/card.py
@@ -113,5 +113,10 @@ class Card(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/cards/delete-card/delete
         """
-        return self._delete(uri="/v1/customers/" + self._path_param(customer_id)
-                            + "/cards/" + self._path_param(card_id), request_options=request_options)
+        return self._delete(
+            uri="/v1/customers/"
+            + self._path_param(customer_id)
+            + "/cards/"
+            + self._path_param(card_id),
+            request_options=request_options,
+        )

--- a/mercadopago/resources/customer.py
+++ b/mercadopago/resources/customer.py
@@ -44,7 +44,10 @@ class Customer(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api/customers/get-customer/get
         """
-        return self._get(uri="/v1/customers/" + self._path_param(customer_id), request_options=request_options)
+        return self._get(
+            uri="/v1/customers/" + self._path_param(customer_id),
+            request_options=request_options,
+        )
 
     def create(self, customer_object, request_options=None):
         """Creates a new customer record.

--- a/mercadopago/resources/order.py
+++ b/mercadopago/resources/order.py
@@ -125,7 +125,10 @@ class Order(MPBase):
         if not isinstance(order_id, str):
             raise ValueError("Param order_id must be a string")
 
-        return self._get(uri="/v1/orders/" + self._path_param(order_id), request_options=request_options)
+        return self._get(
+            uri="/v1/orders/" + self._path_param(order_id),
+            request_options=request_options,
+        )
 
     def process(self, order_id, request_options=None):
         """Processes (executes payment for) an existing order.
@@ -225,8 +228,11 @@ class Order(MPBase):
         if not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._post(uri=f"/v1/orders/{self._path_param(order_id)}/transactions", data=transaction_object,
-                          request_options=request_options)
+        return self._post(
+            uri=f"/v1/orders/{self._path_param(order_id)}/transactions",
+            data=transaction_object,
+            request_options=request_options,
+        )
 
     def update_transaction(
         self, order_id, transaction_id, transaction_object, request_options=None
@@ -249,8 +255,12 @@ class Order(MPBase):
         if not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._put(uri=f"/v1/orders/{self._path_param(order_id)}/transactions/{self._path_param(transaction_id)}",
-                         data=transaction_object, request_options=request_options)
+        return self._put(
+            uri=f"/v1/orders/{self._path_param(order_id)}"
+            f"/transactions/{self._path_param(transaction_id)}",
+            data=transaction_object,
+            request_options=request_options,
+        )
 
     def refund_transaction(self, order_id, transaction_object=None, request_options=None):
         """Refunds an order's transactions.
@@ -275,8 +285,11 @@ class Order(MPBase):
         if transaction_object is not None and not isinstance(transaction_object, dict):
             raise ValueError("Param transaction_object must be a Dictionary")
 
-        return self._post(uri=f"/v1/orders/{self._path_param(order_id)}/refund", data=transaction_object,
-                          request_options=request_options)
+        return self._post(
+            uri=f"/v1/orders/{self._path_param(order_id)}/refund",
+            data=transaction_object,
+            request_options=request_options,
+        )
 
     def refund(self, order_id, refund_object=None, request_options=None):
         """Refunds an order.
@@ -315,5 +328,8 @@ class Order(MPBase):
         if not isinstance(order_id, str) or not isinstance(transaction_id, str):
             raise ValueError("Params order_id and transaction_id must be strings")
 
-        return self._delete(uri=f"/v1/orders/{self._path_param(order_id)}/transactions/{self._path_param(transaction_id)}",
-                            request_options=request_options)
+        return self._delete(
+            uri=f"/v1/orders/{self._path_param(order_id)}"
+            f"/transactions/{self._path_param(transaction_id)}",
+            request_options=request_options,
+        )

--- a/mercadopago/resources/payment.py
+++ b/mercadopago/resources/payment.py
@@ -46,7 +46,10 @@ class Payment(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-payment/get
         """
-        return self._get(uri="/v1/payments/" + self._path_param(payment_id), request_options=request_options)
+        return self._get(
+            uri="/v1/payments/" + self._path_param(payment_id),
+            request_options=request_options,
+        )
 
     def create(self, payment_object, request_options=None):
         """Creates a new payment.

--- a/mercadopago/resources/point.py
+++ b/mercadopago/resources/point.py
@@ -70,7 +70,9 @@ class Point(MPBase):
             raise ValueError("Param payment_intent_object must be a Dictionary")
 
         return self._post(
-            uri="/point/integration-api/devices/" + self._path_param(device_id) + "/payment-intents",
+            uri="/point/integration-api/devices/"
+            + self._path_param(device_id)
+            + "/payment-intents",
             data=payment_intent_object,
             request_options=request_options,
         )

--- a/mercadopago/resources/preapproval.py
+++ b/mercadopago/resources/preapproval.py
@@ -46,7 +46,10 @@ class PreApproval(MPBase):
 
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/subscriptions/get-preapproval/get
         """
-        return self._get(uri="/preapproval/" + self._path_param(preapproval_id), request_options=request_options)
+        return self._get(
+            uri="/preapproval/" + self._path_param(preapproval_id),
+            request_options=request_options,
+        )
 
     def create(self, preapproval_object, request_options=None):
         """Creates a new preapproval (ad-hoc subscription).

--- a/mercadopago/resources/preference.py
+++ b/mercadopago/resources/preference.py
@@ -50,8 +50,11 @@ class Preference(MPBase):
         if not isinstance(preference_object, dict):
             raise ValueError("Param preference_object must be a Dictionary")
 
-        return self._put(uri="/checkout/preferences/" + self._path_param(preference_id), data=preference_object,
-                         request_options=request_options)
+        return self._put(
+            uri="/checkout/preferences/" + self._path_param(preference_id),
+            data=preference_object,
+            request_options=request_options,
+        )
 
     def create(self, preference_object, request_options=None):
         """Creates a new checkout preference.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -17,27 +17,19 @@ class TestOrder(unittest.TestCase):
     """
     sdk = mercadopago.SDK(os.environ['ACCESS_TOKEN'])
 
-    def create_master_test_card(self, status="APRO"):
+    def create_visa_test_card(self, status="APRO"):
         card_token_object = {
-            "card_number": "5031433215406351",
+            "card_number": "4074090000000004",
             "security_code": "123",
             "expiration_year": "2030",
-            "expiration_month": "11",
+            "expiration_month": "12",
             "cardholder": {"name": status}
         }
         card_token_created = self.sdk.card_token().create(card_token_object)
         return card_token_created["response"]["id"]
 
-    def create_visa_test_card(self, status="APRO"):
-        card_token_object = {
-            "card_number": "4235647728025682",
-            "security_code": "123",
-            "expiration_year": "2030",
-            "expiration_month": "11",
-            "cardholder": {"name": status}
-        }
-        card_token_created = self.sdk.card_token().create(card_token_object)
-        return card_token_created["response"]["id"]
+    def create_master_test_card(self, status="APRO"):
+        return self.create_visa_test_card(status)
 
     def create_order_canceled_or_captured(self, card_token_id):
         random_email_id = random.randint(100000, 999999)
@@ -55,7 +47,7 @@ class TestOrder(unittest.TestCase):
                     {
                         "amount": "1000.00",
                         "payment_method": {
-                            "id": "master",
+                            "id": "visa",
                             "type": "credit_card",
                             "token": card_token_id,
                             "installments": 1
@@ -97,7 +89,7 @@ class TestOrder(unittest.TestCase):
                     {
                         "amount": "1000.00",
                         "payment_method": {
-                            "id": "master",
+                            "id": "visa",
                             "type": "credit_card",
                             "token": card_token_id,
                             "installments": 1
@@ -129,7 +121,7 @@ class TestOrder(unittest.TestCase):
                     {
                         "amount": "1000.00",
                         "payment_method": {
-                            "id": "master",
+                            "id": "visa",
                             "type": "credit_card",
                             "token": card_token_id,
                             "installments": 12
@@ -165,7 +157,7 @@ class TestOrder(unittest.TestCase):
                     {
                         "amount": "1000.00",
                         "payment_method": {
-                            "id": "master",
+                            "id": "visa",
                             "type": "credit_card",
                             "token": card_token_id,
                             "installments": 1
@@ -198,7 +190,7 @@ class TestOrder(unittest.TestCase):
                     {
                         "amount": "1000.00",
                         "payment_method": {
-                            "id": "master",
+                            "id": "visa",
                             "type": "credit_card",
                             "token": card_token_id,
                             "installments": 1

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -44,7 +44,7 @@ class TestOrder(unittest.TestCase):
         order_object_cc = {
             "type": "online",
             "processing_mode": "automatic",
-            "total_amount": "200.00",
+            "total_amount": "1000.00",
             "external_reference": "ext_ref_1234",
             "payer": {
                 "email": f"test_payer_{random_email_id}@testuser.com"
@@ -53,7 +53,7 @@ class TestOrder(unittest.TestCase):
             "transactions": {
                 "payments": [
                     {
-                        "amount": "200.00",
+                        "amount": "1000.00",
                         "payment_method": {
                             "id": "master",
                             "type": "credit_card",
@@ -74,7 +74,7 @@ class TestOrder(unittest.TestCase):
         order_object_cc = {
             "type": "online",
             "processing_mode": "manual",
-            "total_amount": "200.00",
+            "total_amount": "1000.00",
             "external_reference": "ext_ref_1234",
             "payer": {
                 "email": f"test_payer_{random_email_id}@testuser.com"
@@ -90,12 +90,12 @@ class TestOrder(unittest.TestCase):
         order_mode_oneshot_complete = {
             "type": "online",
             "processing_mode": "automatic",
-            "total_amount": "200.00",
+            "total_amount": "1000.00",
             "external_reference": "ext_ref_1234",
             "transactions": {
                 "payments": [
                     {
-                        "amount": "200.00",
+                        "amount": "1000.00",
                         "payment_method": {
                             "id": "master",
                             "type": "credit_card",
@@ -122,12 +122,12 @@ class TestOrder(unittest.TestCase):
         order_mode_builder_complete = {
             "type": "online",
             "processing_mode": "manual",
-            "total_amount": "200.00",
+            "total_amount": "1000.00",
             "external_reference": "ext_ref_1234",
             "transactions": {
                 "payments": [
                     {
-                        "amount": "200.00",
+                        "amount": "1000.00",
                         "payment_method": {
                             "id": "master",
                             "type": "credit_card",
@@ -157,23 +157,24 @@ class TestOrder(unittest.TestCase):
         random_email_id = random.randint(100000, 999999)
         order_object = {
             "type": "online",
+            "processing_mode": "automatic",
             "total_amount": "1000.00",
             "external_reference": "ext_ref_1234",
             "transactions": {
-            "payments": [
-                {
-                "amount": "1000.00",
-                "payment_method": {
-                    "id": "master",
-                    "type": "credit_card",
-                    "token": card_token_id,
-                    "installments": 12
-                }
-                }
-            ]
+                "payments": [
+                    {
+                        "amount": "1000.00",
+                        "payment_method": {
+                            "id": "master",
+                            "type": "credit_card",
+                            "token": card_token_id,
+                            "installments": 1
+                        }
+                    }
+                ]
             },
             "payer": {
-            "email": f"test_payer_{random_email_id}@testuser.com"
+                "email": f"test_payer_{random_email_id}@testuser.com"
             }
         }
 
@@ -191,11 +192,11 @@ class TestOrder(unittest.TestCase):
             "type": "online",
             "processing_mode": "manual",
             "external_reference": "ext_ref_1234",
-            "total_amount": "200.00",
+            "total_amount": "1000.00",
             "transactions": {
                 "payments": [
                     {
-                        "amount": "200.00",
+                        "amount": "1000.00",
                         "payment_method": {
                             "id": "master",
                             "type": "credit_card",
@@ -240,7 +241,7 @@ class TestOrder(unittest.TestCase):
         transaction_object = {
             "payments": [
                 {
-                    "amount": "200.00",
+                    "amount": "1000.00",
                     "payment_method": {
                         "id": "master",
                         "type": "credit_card",

--- a/tests/test_order_checkout_pro.py
+++ b/tests/test_order_checkout_pro.py
@@ -317,7 +317,7 @@ class TestOrderCheckoutPro(unittest.TestCase):
         self.assertEqual(order_created["response"]["type"], "online")
         self.assertEqual(order_created["response"]["processing_mode"], "manual")
         self.assertIn("id", order_created["response"])
-        self.assertIn("checkout_url", order_created["response"])
+        self.assertIn("client_token", order_created["response"])
 
 
 if __name__ == "__main__":

--- a/tests/test_path_param.py
+++ b/tests/test_path_param.py
@@ -10,7 +10,7 @@ class TestPathParam(unittest.TestCase):
 
         self.assertEqual(
             "..%2F..%2Fapplications%2F123",
-            base._path_param("../../applications/123"),
+            base._path_param("../../applications/123"),  # pylint: disable=protected-access
         )
 
 

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -18,10 +18,10 @@ class TestPayment(unittest.TestCase):
         Test Function: Payment
         """
         card_token_object = {
-            "card_number": "4074090000000004",
+            "card_number": "5031433215406351",
             "security_code": "123",
-            "expiration_year": datetime.now().strftime("%Y"),
-            "expiration_month": "12",
+            "expiration_year": "2030",
+            "expiration_month": "11",
             "cardholder": {
                 "name": "APRO",
                 "identification": {
@@ -37,7 +37,7 @@ class TestPayment(unittest.TestCase):
             "installments": 1,
             "transaction_amount": 58.80,
             "description": "Point Mini a maquininha que dá o dinheiro de suas vendas na hora",
-            "payment_method_id": "visa",
+            "payment_method_id": "master",
             "payer": {
                 "email": "test_user_123456@testuser.com",
                 "identification": {

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,7 +1,6 @@
 """
     Module: test_payment
 """
-from datetime import datetime
 import os
 import unittest
 import mercadopago
@@ -18,10 +17,10 @@ class TestPayment(unittest.TestCase):
         Test Function: Payment
         """
         card_token_object = {
-            "card_number": "5031433215406351",
+            "card_number": "4074090000000004",
             "security_code": "123",
             "expiration_year": "2030",
-            "expiration_month": "11",
+            "expiration_month": "12",
             "cardholder": {
                 "name": "APRO",
                 "identification": {
@@ -37,7 +36,7 @@ class TestPayment(unittest.TestCase):
             "installments": 1,
             "transaction_amount": 58.80,
             "description": "Point Mini a maquininha que dá o dinheiro de suas vendas na hora",
-            "payment_method_id": "master",
+            "payment_method_id": "visa",
             "payer": {
                 "email": "test_user_123456@testuser.com",
                 "identification": {
@@ -75,10 +74,6 @@ class TestPayment(unittest.TestCase):
                     "is_prime_user": False,
                     "is_first_purchase_online": False,
                     "last_purchase": "2024-01-01T12:01:01.000-03:00",
-                    "identification": {
-                        "type": "CPF",
-                        "number": "19119119100"
-                    },
                     "phone": {
                         "area_code": "011",
                         "number": "987654321"

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,7 +1,6 @@
 """
     Module: test_plan
 """
-from datetime import datetime
 import os
 import unittest
 import random
@@ -126,9 +125,9 @@ class TestSubscription(unittest.TestCase):
     @classmethod
     def create_card_token(cls):
         card_token_object = {
-            "card_number": "5031433215406351",
+            "card_number": "4074090000000004",
             "security_code": "123",
-            "expiration_year": datetime.now().strftime("%Y"),
+            "expiration_year": "2030",
             "expiration_month": "12",
             "cardholder": {
                 "name": "APRO",

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -51,8 +51,8 @@ class TestSubscription(unittest.TestCase):
             "auto_recurring": {
                 "frequency": 1,
                 "frequency_type": "months",
-                "transaction_amount": 60,
-                "currency_id": "ARS"
+                "transaction_amount": 100,
+                "currency_id": "BRL"
             }
         }
 
@@ -106,7 +106,7 @@ class TestSubscription(unittest.TestCase):
             "auto_recurring": {
                 "frequency": 1,
                 "frequency_type": "months",
-                "transaction_amount": 60,
+                "transaction_amount": 100,
                 "currency_id": "BRL",
             },
             "status": "authorized"
@@ -169,7 +169,7 @@ class TestSubscription(unittest.TestCase):
             "auto_recurring": {
                 "frequency": 1,
                 "frequency_type": "months",
-                "transaction_amount": 60,
+                "transaction_amount": 100,
                 "currency_id": "BRL",
             },
             "back_url": "https://www.mercadopago.com.co/subscriptions",


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA commit hashes to prevent supply chain attacks via mutable tags

## Changes
- `cd.yml`: `actions/checkout@v7` → `@df4cb1c...`, `actions/setup-python@v7` → `@ece7cb06...`
- `ci.yml`: `actions/checkout@v7` → `@df4cb1c...`, `actions/setup-python@v7` → `@ece7cb06...`

## Test plan
- [ ] CI passes on this PR