### PR TITLE
Add capture method to Payment resource

### DIFF
--- a/mercadopago/resources/payment.py
+++ b/mercadopago/resources/payment.py
@@ -96,3 +96,26 @@ class Payment(MPBase):
 
         return self._put(uri="/v1/payments/" + self._path_param(payment_id), data=payment_object,
                          request_options=request_options)
+
+    def capture(self, payment_id, amount=None, request_options=None):
+        """Captures an authorized payment.
+
+        Args:
+            payment_id: Identifier of the authorized payment to capture.
+            amount: Amount to capture. If ``None``, the full authorized amount
+                is captured.
+            request_options: Per-call configuration overrides.
+
+        Returns:
+            dict: Updated payment object reflecting the captured state.
+
+        Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/update-payment/put
+        """
+        payload = {"capture": True}
+        if amount is not None:
+            payload["transaction_amount"] = amount
+        return self._put(
+            uri="/v1/payments/" + self._path_param(payment_id),
+            data=payload,
+            request_options=request_options,
+        )

--- a/mercadopago/resources/refund.py
+++ b/mercadopago/resources/refund.py
@@ -58,3 +58,21 @@ class Refund(MPBase):
 
         return self._post(uri="/v1/payments/" + self._path_param(payment_id) + "/refunds",
                           data=refund_object, request_options=request_options)
+
+    def get(self, payment_id, refund_id, request_options=None):
+        """Retrieves a single refund by its ID.
+
+        Args:
+            payment_id: Identifier of the parent payment.
+            refund_id: Identifier of the refund to retrieve.
+            request_options: Per-call configuration overrides.
+
+        Returns:
+            dict: Refund object including its ``id`` and ``status``.
+
+        Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-refund/get
+        """
+        return self._get(
+            uri="/v1/payments/" + self._path_param(payment_id) + "/refunds/" + self._path_param(refund_id),
+            request_options=request_options,
+        )

--- a/mercadopago/resources/refund.py
+++ b/mercadopago/resources/refund.py
@@ -73,6 +73,7 @@ class Refund(MPBase):
         Reference: https://www.mercadopago.com/developers/en/reference/online-payments/checkout-api-payments/get-refund/get
         """
         return self._get(
-            uri="/v1/payments/" + self._path_param(payment_id) + "/refunds/" + self._path_param(refund_id),
+            uri=f"/v1/payments/{self._path_param(payment_id)}"
+                f"/refunds/{self._path_param(refund_id)}",
             request_options=request_options,
         )

--- a/tests/test_payment_capture.py
+++ b/tests/test_payment_capture.py
@@ -1,0 +1,72 @@
+"""
+    Module: test_payment_capture
+"""
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mercadopago
+from mercadopago.http.http_client import HttpClient
+
+
+PAYMENT_ID = 123456789
+
+CAPTURED_PAYMENT_RESPONSE = {
+    "id": PAYMENT_ID,
+    "status": "approved",
+    "captured": True,
+    "transaction_amount": 100.0,
+}
+
+
+class TestPaymentCapture(unittest.TestCase):
+    """
+    Test Module: Payment.capture
+    """
+
+    def _make_sdk_with_mock_put(self, return_value):
+        mock_http = MagicMock(spec=HttpClient)
+        mock_http.put.return_value = return_value
+        return mercadopago.SDK("TEST_ACCESS_TOKEN", http_client=mock_http), mock_http
+
+    def test_capture_full(self):
+        """Captures the full authorized amount when no amount is given."""
+        sdk, mock_http = self._make_sdk_with_mock_put(
+            {"status": 200, "response": CAPTURED_PAYMENT_RESPONSE}
+        )
+
+        result = sdk.payment().capture(PAYMENT_ID)
+
+        self.assertEqual(result["status"], 200)
+        self.assertTrue(result["response"]["captured"])
+
+        mock_http.put.assert_called_once()
+        call_kwargs = mock_http.put.call_args
+        url = call_kwargs[1]["url"] if "url" in call_kwargs[1] else call_kwargs[0][0]
+        self.assertIn(str(PAYMENT_ID), url)
+
+        body = json.loads(call_kwargs[1]["data"])
+        self.assertTrue(body["capture"])
+        self.assertNotIn("transaction_amount", body)
+
+    def test_capture_partial(self):
+        """Captures a specific amount and includes transaction_amount in the request body."""
+        partial_amount = 50.0
+        response_body = dict(CAPTURED_PAYMENT_RESPONSE, transaction_amount=partial_amount)
+        sdk, mock_http = self._make_sdk_with_mock_put(
+            {"status": 200, "response": response_body}
+        )
+
+        result = sdk.payment().capture(PAYMENT_ID, amount=partial_amount)
+
+        self.assertEqual(result["status"], 200)
+
+        mock_http.put.assert_called_once()
+        call_kwargs = mock_http.put.call_args
+        body = json.loads(call_kwargs[1]["data"])
+        self.assertTrue(body["capture"])
+        self.assertEqual(body["transaction_amount"], partial_amount)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_payment_capture.py
+++ b/tests/test_payment_capture.py
@@ -3,7 +3,7 @@
 """
 import json
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import mercadopago
 from mercadopago.http.http_client import HttpClient

--- a/tests/test_refund_get.py
+++ b/tests/test_refund_get.py
@@ -14,6 +14,7 @@ class TestRefundGet(unittest.TestCase):
         return Refund(request_options, http_client)
 
     def test_get_returns_refund_by_id(self):
+        """Verifies get() returns the correct refund and calls the expected URL."""
         http_client = MagicMock()
         http_client.get.return_value = {"status": 200, "response": {"id": 99, "status": "approved"}}
 
@@ -23,10 +24,16 @@ class TestRefundGet(unittest.TestCase):
         self.assertEqual(result["status"], 200)
         self.assertEqual(result["response"]["id"], 99)
         http_client.get.assert_called_once()
-        called_url = http_client.get.call_args.kwargs.get("url") or http_client.get.call_args[1].get("url") or http_client.get.call_args[0][0]
+        call_args = http_client.get.call_args
+        called_url = (
+            call_args.kwargs.get("url")
+            or call_args[1].get("url")
+            or call_args[0][0]
+        )
         self.assertIn("/v1/payments/123/refunds/99", called_url)
 
     def test_get_passes_request_options(self):
+        """Verifies custom request_options are forwarded to the HTTP client."""
         http_client = MagicMock()
         http_client.get.return_value = {"status": 200, "response": {"id": 55}}
 

--- a/tests/test_refund_get.py
+++ b/tests/test_refund_get.py
@@ -1,0 +1,42 @@
+"""Unit tests for Refund.get() using MagicMock."""
+import unittest
+from unittest.mock import MagicMock
+
+from mercadopago.config.request_options import RequestOptions
+from mercadopago.resources.refund import Refund
+
+
+class TestRefundGet(unittest.TestCase):
+    """Unit tests for Refund.get()."""
+
+    def _make_refund(self, http_client):
+        request_options = RequestOptions(access_token="TEST_TOKEN")
+        return Refund(request_options, http_client)
+
+    def test_get_returns_refund_by_id(self):
+        http_client = MagicMock()
+        http_client.get.return_value = {"status": 200, "response": {"id": 99, "status": "approved"}}
+
+        refund = self._make_refund(http_client)
+        result = refund.get(payment_id=123, refund_id=99)
+
+        self.assertEqual(result["status"], 200)
+        self.assertEqual(result["response"]["id"], 99)
+        http_client.get.assert_called_once()
+        called_url = http_client.get.call_args.kwargs.get("url") or http_client.get.call_args[1].get("url") or http_client.get.call_args[0][0]
+        self.assertIn("/v1/payments/123/refunds/99", called_url)
+
+    def test_get_passes_request_options(self):
+        http_client = MagicMock()
+        http_client.get.return_value = {"status": 200, "response": {"id": 55}}
+
+        custom_options = RequestOptions(access_token="CUSTOM_TOKEN")
+        refund = self._make_refund(http_client)
+        result = refund.get(payment_id=10, refund_id=55, request_options=custom_options)
+
+        self.assertEqual(result["status"], 200)
+        http_client.get.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `Payment.capture(payment_id, amount=None)` — brings Python to parity with PHP, Node.js, Java, .NET and Go
- Sends `PUT /v1/payments/{id}` with `{"capture": true}`, optionally including `transaction_amount` for partial capture

## Test plan
- [ ] All 53 existing tests pass
- [ ] Manual: `sdk.payment().capture(payment_id)` captures full authorized amount
- [ ] Manual: `sdk.payment().capture(payment_id, amount=50.0)` performs partial capture

🤖 Generated with [Claude Code](https://claude.ai/claude-code)