### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-08-04
+
+### Added
+
+- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#141](https://github.com/mercadopago/sdk-python/pull/141))
+  - `MPApiException` now has 12 specific subtypes per HTTP status code
+  - Request options gain optional `max_retries`, `retry_on`, `initial_delay_ms`, `max_delay_ms` and `on_retry` callback
+  - New auto-pagination support on search endpoints
+- **Missing API methods** — `disbursement_refund.list()`, `advanced_payment.update()`, `customer_card.update()`, `payment.update()` ([#140](https://github.com/mercadopago/sdk-python/pull/140))
+- **CREDENTIAL_ON_FILE messaging fields** on Payment types ([#139](https://github.com/mercadopago/sdk-python/pull/139)): `first_transaction`, `storage`, `transaction_initiator`, `reference`
+
+### Fixed
+
+- Webhook `tolerance_seconds` unit mismatch — `ts` header value compared in seconds against a millisecond clock ([#142](https://github.com/mercadopago/sdk-python/pull/142))
+- `constant_time_equals` error on multibyte v1 hash ([#142](https://github.com/mercadopago/sdk-python/pull/142))
+
+### Dependencies
+
+- Bump `actions/checkout` to `v7.0.1` ([#138](https://github.com/mercadopago/sdk-python/pull/138))
+
 ## [3.3.0] - 2026-06-30
 
 ### Added

--- a/mercadopago/config/config.py
+++ b/mercadopago/config/config.py
@@ -26,7 +26,7 @@ class Config:
 
     def __init__(self):
         """Builds version-dependent values (user_agent, tracking_id)."""
-        self.__version = "3.3.0-beta.1"
+        self.__version = "3.4.0"
         self.__user_agent = "MercadoPago Python SDK v" + self.__version
         self.__product_id = "bc32bpftrpp001u8nhlg"
         self.__tracking_id = "platform:" + platform.python_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mercadopago"
-version = "3.3.1"
+version = "3.4.0"
 authors = [
     {name = "Mercado Pago", email = "mp_sdk@mercadopago.com"}
 ]


### PR DESCRIPTION
## Summary

- Bump version from `3.3.1` to `3.4.0`
- Update `pyproject.toml`, `mercadopago/config/config.py`, and `CHANGELOG.md`
- Note: `config.py` was on `3.3.0-beta.1` in master — updated directly to `3.4.0`

## Changelog entry

### Added
- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#141](https://github.com/mercadopago/sdk-python/pull/141))
  - `MPApiException` now has 12 specific subtypes per HTTP status code
  - Request options gain optional `max_retries`, `retry_on`, `initial_delay_ms`, `max_delay_ms` and `on_retry` callback
  - New auto-pagination support on search endpoints
- **Missing API methods** — `disbursement_refund.list()`, `advanced_payment.update()`, `customer_card.update()`, `payment.update()` ([#140](https://github.com/mercadopago/sdk-python/pull/140))
- **CREDENTIAL_ON_FILE messaging fields** on Payment types ([#139](https://github.com/mercadopago/sdk-python/pull/139)): `first_transaction`, `storage`, `transaction_initiator`, `reference`

### Fixed
- Webhook `tolerance_seconds` unit mismatch ([#142](https://github.com/mercadopago/sdk-python/pull/142))
- `constant_time_equals` error on multibyte v1 hash ([#142](https://github.com/mercadopago/sdk-python/pull/142))

### Dependencies
- Bump `actions/checkout` to `v7.0.1` ([#138](https://github.com/mercadopago/sdk-python/pull/138))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files