### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-08-11
+
+### Changed
+- **Item and shipment classes**: renamed to generic classes without `Order` prefix ([#145](https://github.com/mercadopago/sdk-python/pull/145))
+- **Payer classes**: consolidated into a single generic `payer.py` ([#145](https://github.com/mercadopago/sdk-python/pull/145))
+
+### CI
+- Add Python 3.13 and 3.14 to CI matrix ([#145](https://github.com/mercadopago/sdk-python/pull/145))
+- Drop Python 3.9 from CI matrix — not supported by this SDK ([#145](https://github.com/mercadopago/sdk-python/pull/145))
+- Standardize CI/CD workflows ([#145](https://github.com/mercadopago/sdk-python/pull/145))
+
 ## [3.4.0] - 2026-08-04
 
 ### Added

--- a/mercadopago/config/config.py
+++ b/mercadopago/config/config.py
@@ -26,7 +26,7 @@ class Config:
 
     def __init__(self):
         """Builds version-dependent values (user_agent, tracking_id)."""
-        self.__version = "3.4.0"
+        self.__version = "3.5.0"
         self.__user_agent = "MercadoPago Python SDK v" + self.__version
         self.__product_id = "bc32bpftrpp001u8nhlg"
         self.__tracking_id = "platform:" + platform.python_version()

--- a/mercadopago/resources/__init__.py
+++ b/mercadopago/resources/__init__.py
@@ -14,6 +14,7 @@ from mercadopago.resources.customer import Customer
 from mercadopago.resources.disbursement_refund import DisbursementRefund
 from mercadopago.resources.identification_type import IdentificationType
 from mercadopago.resources.invoice import Invoice
+from mercadopago.resources.item import ItemRequest
 from mercadopago.resources.merchant_order import MerchantOrder
 from mercadopago.resources.oauth import OAuth
 from mercadopago.resources.order import Order
@@ -35,18 +36,6 @@ from mercadopago.resources.order_integration_data import (
     OrderIntegrationData,
     OrderSponsor,
 )
-from mercadopago.resources.item import ItemRequest
-from mercadopago.resources.payer import (
-    PayerAddress,
-    PayerIdentification,
-    PayerPhone,
-    PayerRequest,
-)
-from mercadopago.resources.shipment import (
-    ShipmentAddress,
-    ShipmentFreeMethod,
-    ShipmentRequest,
-)
 from mercadopago.resources.order_stored_credential import OrderStoredCredential
 from mercadopago.resources.order_subscription_data import (
     OrderInvoicePeriod,
@@ -59,6 +48,12 @@ from mercadopago.resources.order_transaction import (
     OrderTransactionRequest,
 )
 from mercadopago.resources.order_transaction_security import OrderTransactionSecurity
+from mercadopago.resources.payer import (
+    PayerAddress,
+    PayerIdentification,
+    PayerPhone,
+    PayerRequest,
+)
 from mercadopago.resources.payment import Payment
 from mercadopago.resources.payment_methods import PaymentMethods
 from mercadopago.resources.plan import Plan
@@ -66,6 +61,11 @@ from mercadopago.resources.point import Point
 from mercadopago.resources.preapproval import PreApproval
 from mercadopago.resources.preference import Preference
 from mercadopago.resources.refund import Refund
+from mercadopago.resources.shipment import (
+    ShipmentAddress,
+    ShipmentFreeMethod,
+    ShipmentRequest,
+)
 from mercadopago.resources.subscription import Subscription
 from mercadopago.resources.user import User
 

--- a/mercadopago/resources/order_create.py
+++ b/mercadopago/resources/order_create.py
@@ -23,9 +23,9 @@ from typing import (
 
 from mercadopago.resources.item import ItemRequest
 from mercadopago.resources.order_integration_data import OrderIntegrationData
-from mercadopago.resources.shipment import ShipmentRequest
 from mercadopago.resources.order_transaction import OrderTransactionRequest
 from mercadopago.resources.payer import PayerRequest
+from mercadopago.resources.shipment import ShipmentRequest
 
 
 def _filter_none(value):

--- a/mercadopago/resources/order_transaction.py
+++ b/mercadopago/resources/order_transaction.py
@@ -9,7 +9,10 @@ The plain dict path continues to work unchanged; these dataclasses are
 purely additive.
 """
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
 from mercadopago.resources.order_automatic_payments import OrderAutomaticPayments
 from mercadopago.resources.order_stored_credential import OrderStoredCredential

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mercadopago"
-version = "3.4.0"
+version = "3.5.0"
 authors = [
     {name = "Mercado Pago", email = "mp_sdk@mercadopago.com"}
 ]

--- a/tests/test_order_request_dataclasses.py
+++ b/tests/test_order_request_dataclasses.py
@@ -12,6 +12,7 @@ import unittest
 
 import mercadopago
 from mercadopago.http import HttpClient
+from mercadopago.resources.item import ItemRequest
 from mercadopago.resources.order_automatic_payments import OrderAutomaticPayments
 from mercadopago.resources.order_create import (
     OrderCreateRequest,
@@ -20,18 +21,6 @@ from mercadopago.resources.order_create import (
 from mercadopago.resources.order_integration_data import (
     OrderIntegrationData,
     OrderSponsor,
-)
-from mercadopago.resources.item import ItemRequest
-from mercadopago.resources.payer import (
-    PayerAddress,
-    PayerIdentification,
-    PayerPhone,
-    PayerRequest,
-)
-from mercadopago.resources.shipment import (
-    ShipmentAddress,
-    ShipmentFreeMethod,
-    ShipmentRequest,
 )
 from mercadopago.resources.order_stored_credential import OrderStoredCredential
 from mercadopago.resources.order_subscription_data import (
@@ -45,6 +34,17 @@ from mercadopago.resources.order_transaction import (
     OrderTransactionRequest,
 )
 from mercadopago.resources.order_transaction_security import OrderTransactionSecurity
+from mercadopago.resources.payer import (
+    PayerAddress,
+    PayerIdentification,
+    PayerPhone,
+    PayerRequest,
+)
+from mercadopago.resources.shipment import (
+    ShipmentAddress,
+    ShipmentFreeMethod,
+    ShipmentRequest,
+)
 
 
 class _CapturingHttpClient(HttpClient):


### PR DESCRIPTION
## Summary
- Bump version from \`3.4.0\` to \`3.5.0\`
- Update \`pyproject.toml\`, \`mercadopago/config/config.py\`, \`CHANGELOG.md\`

## Changelog entry
### Changed
- Item and shipment classes: renamed to generic classes without \`Order\` prefix ([#145](https://github.com/mercadopago/sdk-python/pull/145))
- Payer classes: consolidated into a single generic \`payer.py\` ([#145](https://github.com/mercadopago/sdk-python/pull/145))
### CI
- Add Python 3.13 and 3.14 to CI matrix ([#145](https://github.com/mercadopago/sdk-python/pull/145))
- Drop Python 3.9 from CI matrix — not supported by this SDK ([#145](https://github.com/mercadopago/sdk-python/pull/145))
- Standardize CI/CD workflows ([#145](https://github.com/mercadopago/sdk-python/pull/145))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files