### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-08-27
+
+### Added
+- **Credential-on-file and automatic payments**: support `network_data`, expanded gateway network data, and `automatic_payments.subscription`.
+
+### CI
+- Publish to PyPI through GitHub OIDC trusted publishing.
+
 ## [3.5.0] - 2026-08-11
 
 ### Changed

--- a/mercadopago/config/config.py
+++ b/mercadopago/config/config.py
@@ -26,7 +26,7 @@ class Config:
 
     def __init__(self):
         """Builds version-dependent values (user_agent, tracking_id)."""
-        self.__version = "3.5.0"
+        self.__version = "3.6.0"
         self.__user_agent = "MercadoPago Python SDK v" + self.__version
         self.__product_id = "bc32bpftrpp001u8nhlg"
         self.__tracking_id = "platform:" + platform.python_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mercadopago"
-version = "3.5.0"
+version = "3.6.0"
 authors = [
     {name = "Mercado Pago", email = "mp_sdk@mercadopago.com"}
 ]


### PR DESCRIPTION
## Summary

Bumps the Python SDK release version to 3.6.0 after the latest merged backwards-compatible functionality.

## Files updated

- pyproject.toml
- mercadopago/config/config.py
- CHANGELOG.md

## Validation

- Confirmed version metadata and changelog consistency.
- No runtime code changes.